### PR TITLE
Add extraction tutorial and fix missing data in Wölfel et al. (2020) dataset.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ cython_debug/
 
 playground
 *.ipynb
+.DS_Store

--- a/data/woelfel2020.yaml
+++ b/data/woelfel2020.yaml
@@ -6,7 +6,9 @@ description: >
   Munich in early 2020. They quantified SARS-CoV-2 RNA gene copies in throat swabs and
   RNA concentrations in stool and sputum samples. Abundances were quantified using
   RT-qPCR assays targeting the E and RdRP genes as described in
-  10.2807/1560-7917.ES.2020.25.3.2000045.
+  10.2807/1560-7917.ES.2020.25.3.2000045. Values were programmatically extracted from
+  the figure, resulting in a number of significant figures far exceeding the performance
+  of the assays.
 analytes:
   stool:
     description: >
@@ -33,99 +35,111 @@ participants:
 - measurements:
   - analyte: sputum
     time: 4
-    value: 1501607.864283418
+    value: 1562714.6317999878
   - analyte: sputum
     time: 5
-    value: 266466197.21909598
+    value: 277334547.2823365
   - analyte: sputum
     time: 6
-    value: 429901652.26021963
+    value: 447331117.4662757
   - analyte: sputum
     time: 7
-    value: 58652351.05120688
+    value: 61048898.110745564
   - analyte: sputum
     time: 8
-    value: 13975627.26687342
+    value: 14546606.024275968
   - analyte: sputum
     time: 9
-    value: 148947.19238484555
+    value: 143159.1720673627
   - analyte: sputum
     time: 10
-    value: 492133.5149670397
+    value: 473027.17940028297
   - analyte: sputum
     time: 11
-    value: 27958.99554973516
+    value: 26865.338030804833
   - analyte: sputum
     time: 12
-    value: 14778.880441454066
+    value: 14203.813667736702
   - analyte: sputum
     time: 13
-    value: 1465.9403684378271
+    value: 1409.0737262519558
   - analyte: sputum
     time: 14
-    value: 2016.3077911902406
+    value: 2098.635477181512
   - analyte: sputum
     time: 15
-    value: 3521.497787720782
+    value: 3384.963572126964
   - analyte: sputum
     time: 16
-    value: 6152.199644988521
+    value: 6403.219358965269
   - analyte: sputum
     time: 17
-    value: 161339.8908700465
+    value: 155033.20512838956
   - analyte: sputum
     time: 18
-    value: 13647.858371306778
+    value: 14203.813667736702
   - analyte: sputum
     time: 19
-    value: 3251.998908312097
+    value: 3384.963572126964
   - analyte: sputum
     time: 20
-    value: 1250.1532821622638
+    value: 1301.1524070927223
   - analyte: sputum
     time: 21
-    value: 6152.199644988521
+    value: 6403.219358965269
   - analyte: sputum
     time: 22
-    value: 2561.063362581965
+    value: 2460.9297476859733
   - analyte: throat_swab
     time: 4
-    value: 68775761.6597049
+    value: 71586624.89816013
   - analyte: throat_swab
     time: 5
-    value: 9160.337817942922
+    value: 9536.778001420955
   - analyte: throat_swab
     time: 6
     value: negative
   - analyte: throat_swab
     time: 7
-    value: 18.32574949197495
+    value: 17.613288717623746
   - analyte: throat_swab
     time: 8
-    value: 1353.7461627157616
+    value: 1301.1524070927223
   - analyte: throat_swab
     time: 9
-    value: 71.00132017315356
+    value: 73.89551617274573
   - analyte: throat_swab
     time: 10
-    value: 480.5881788240554
+    value: 461.7502736841163
   - analyte: throat_swab
     time: 11
-    value: 12.303968525272445
+    value: 12.80686137120952
   - analyte: throat_swab
     time: 12
-    value: 105.75062870326238
+    value: 101.64192237647795
   - analyte: throat_swab
     time: 13
     value: negative
   - analyte: throat_swab
     time: 14
-    value: 1250.1444864268105
+    value: 1301.1524070927223
   - analyte: throat_swab
     time: 15
     value: negative
   - analyte: throat_swab
     time: 16
+    value: negative
+  - analyte: throat_swab
+    time: 17
+    value: negative
+  - analyte: throat_swab
+    time: 18
+    value: negative
+  - analyte: throat_swab
+    time: 19
+    value: negative
+  - analyte: throat_swab
+    time: 20
     value: negative
   - analyte: throat_swab
     time: 21
@@ -135,119 +149,119 @@ participants:
     value: negative
   - analyte: stool
     time: 8
-    value: 4231336.283859664
+    value: 4402370.718610823
   - analyte: stool
     time: 9
-    value: 13980675.735082213
+    value: 14546606.024275968
   - analyte: stool
     time: 10
-    value: 4961700.904561935
+    value: 4767515.99505237
   - analyte: stool
     time: 11
-    value: 48833.244816394516
+    value: 46919.098622083766
   - analyte: stool
     time: 12
-    value: 52896.39060004787
+    value: 50804.03073625913
   - analyte: stool
     time: 13
-    value: 4845.346026026727
+    value: 4655.2563020744055
   - analyte: stool
     time: 14
-    value: 4845.346026026727
+    value: 5041.471222608319
   - analyte: stool
     time: 15
-    value: 5681.693949014843
+    value: 5458.908343750755
   - analyte: stool
     time: 16
-    value: 984.5950370910736
+    value: 1024.4220877795892
   - analyte: stool
     time: 17
-    value: 275.188317392778
+    value: 264.3929136034521
   - analyte: stool
     time: 20
-    value: 3003.2937137549766
+    value: 2886.634471427905
   - analyte: stool
     time: 21
-    value: 661.0587981946713
+    value: 635.140918890549
 - measurements:
   - analyte: sputum
     time: 3
-    value: 10745.042599762002
+    value: 11183.143016477394
   - analyte: sputum
     time: 4
-    value: 246078257.89442512
+    value: 236505784.2557526
   - analyte: sputum
     time: 5
-    value: 12906289.73269271
+    value: 12405077.188340519
   - analyte: sputum
     time: 6
-    value: 24416389.227142632
+    value: 23458775.096724078
   - analyte: sputum
     time: 7
-    value: 6300055.166771174
+    value: 6055379.893517211
   - analyte: sputum
     time: 8
-    value: 305138.15006280725
+    value: 293276.49312569416
   - analyte: sputum
     time: 9
-    value: 3331177.3165422445
+    value: 3200603.1471007746
   - analyte: sputum
     time: 10
-    value: 174713.28010097204
+    value: 167870.05611348746
   - analyte: sputum
     time: 11
-    value: 1719.53459991949
+    value: 1789.140442430319
   - analyte: sputum
     time: 12
-    value: 4472.991209582934
+    value: 4655.2563020744055
   - analyte: sputum
     time: 13
-    value: 78757.66815664191
+    value: 75674.6381019597
   - analyte: sputum
     time: 14
-    value: 38444.63935566572
+    value: 40012.49221209267
   - analyte: sputum
     time: 15
-    value: 78757.66815664191
+    value: 81969.76294093062
   - analyte: sputum
     time: 16
-    value: 3252.0522960060794
+    value: 3384.963572126964
   - analyte: sputum
     time: 17
-    value: 10745.042599762002
+    value: 10327.979541995015
   - analyte: sputum
     time: 18
-    value: 27950.865948018676
+    value: 29089.805625860645
   - analyte: sputum
     time: 19
-    value: 409.7290937235602
+    value: 393.83860988854093
   - analyte: sputum
     time: 20
-    value: 1250.173805785654
+    value: 1201.6546172816657
   - analyte: throat_swab
     time: 3
-    value: 50007790.10644746
+    value: 48057747.149824694
   - analyte: throat_swab
     time: 4
-    value: 1386817.2275983708
+    value: 1332529.190723878
   - analyte: throat_swab
     time: 5
-    value: 92358.84242602295
+    value: 88770.23608916711
   - analyte: throat_swab
     time: 6
-    value: 32777.882892997055
+    value: 34121.27481679463
   - analyte: throat_swab
     time: 7
-    value: 16005.058602699997
+    value: 15382.207382497167
   - analyte: throat_swab
     time: 8
-    value: 25.200583799342535
+    value: 24.219028452872582
   - analyte: throat_swab
     time: 9
-    value: 443.71736449771936
+    value: 461.7502736841163
   - analyte: throat_swab
     time: 10
-    value: 76.89271796049087
+    value: 80.0276255036308
   - analyte: throat_swab
     time: 11
     value: negative
@@ -256,459 +270,489 @@ participants:
     value: negative
   - analyte: throat_swab
     time: 13
-    value: 14.429159320115783
+    value: 13.867277885677378
   - analyte: throat_swab
     time: 14
-    value: 15.62492917650818
+    value: 16.261231185381174
   - analyte: throat_swab
     time: 15
+    value: negative
+  - analyte: throat_swab
+    time: 16
+    value: negative
+  - analyte: throat_swab
+    time: 17
+    value: negative
+  - analyte: throat_swab
+    time: 18
+    value: negative
+  - analyte: throat_swab
+    time: 19
     value: negative
   - analyte: throat_swab
     time: 20
     value: negative
   - analyte: stool
     time: 6
-    value: 533137.5010379844
+    value: 554687.4004119717
   - analyte: stool
     time: 7
     value: negative
   - analyte: stool
     time: 8
-    value: 72736.85590576574
+    value: 75674.6381019597
   - analyte: stool
     time: 9
-    value: 57282.82881446251
+    value: 59593.500412576206
   - analyte: stool
     time: 10
-    value: 4474.764418817172
+    value: 4299.273628149706
   - analyte: stool
     time: 11
-    value: 1719.6878508196692
+    value: 1789.140442430319
   - analyte: stool
     time: 12
-    value: 660.8898318357745
+    value: 687.8213316116323
   - analyte: stool
     time: 13
-    value: 6664.809319460357
+    value: 6934.450873496918
   - analyte: stool
     time: 14
-    value: 7815.212077385447
+    value: 7508.627950290498
   - analyte: stool
     time: 15
-    value: 1250.2881578555023
+    value: 1301.1524070927223
   - analyte: stool
     time: 19
-    value: 200.08377679863366
+    value: 192.24728418871337
 - measurements:
   - analyte: sputum
     time: 3
-    value: 2117582.404638246
+    value: 2203838.4736641357
   - analyte: sputum
     time: 5
-    value: 751754.7228450703
+    value: 782093.6370119494
   - analyte: sputum
     time: 6
-    value: 4588.820093394054
+    value: 4774.136395527701
   - analyte: sputum
     time: 7
-    value: 80772.29234133867
+    value: 84063.00388116004
   - analyte: sputum
     time: 8
-    value: 130273.46700914283
+    value: 135567.84984816503
   - analyte: sputum
     time: 9
-    value: 74590.81968809298
+    value: 71664.51716032202
   - analyte: sputum
     time: 10
-    value: 111097.1536541354
+    value: 106735.15187014615
   - analyte: sputum
     time: 11
-    value: 20847.728791568774
+    value: 21694.99155413058
   - analyte: sputum
     time: 12
-    value: 36410.640757529545
+    value: 37890.03307397511
   - analyte: sputum
     time: 13
-    value: 11023.313195444749
+    value: 10590.13286675745
   - analyte: sputum
     time: 14
-    value: 1628.5588221699336
+    value: 1694.776114117374
   - analyte: sputum
     time: 15
-    value: 10179.703250863166
+    value: 9780.316270097399
   - analyte: sputum
     time: 16
-    value: 15157.173601835617
+    value: 15775.01889114265
   - analyte: sputum
     time: 17
-    value: 16418.31867306646
+    value: 15775.01889114265
   - analyte: sputum
     time: 18
-    value: 2845.1650715599785
+    value: 2959.960950994908
   - analyte: sputum
     time: 19
-    value: 6832.586784679945
+    value: 6566.736739406078
   - analyte: sputum
     time: 20
     value: negative
   - analyte: sputum
     time: 21
-    value: 161.5897029380132
+    value: 168.1567942255867
   - analyte: sputum
     time: 22
-    value: 1910.2531934646609
+    value: 1987.9475051914758
+  - analyte: throat_swab
+    time: 3
+    value: 1602230.4356814811
+  - analyte: throat_swab
+    time: 5
+    value: 18495.535413233774
+  - analyte: throat_swab
+    time: 6
+    value: 6566.736739406078
+  - analyte: throat_swab
+    time: 7
+    value: 3471.9256070275005
+  - analyte: throat_swab
+    time: 8
+    value: 271.226055714882
+  - analyte: throat_swab
+    time: 9
+    value: 59.70201220820101
+  - analyte: throat_swab
+    time: 10
+    value: negative
+  - analyte: throat_swab
+    time: 11
+    value: 43.40444282759396
+  - analyte: throat_swab
+    time: 12
+    value: 31.555815080468644
+  - analyte: throat_swab
+    time: 13
+    value: 168.1567942255867
+  - analyte: throat_swab
+    time: 14
+    value: negative
+  - analyte: throat_swab
+    time: 15
+    value: negative
+  - analyte: throat_swab
+    time: 16
+    value: 3.9772199780789097
+  - analyte: throat_swab
+    time: 17
+    value: negative
+  - analyte: throat_swab
+    time: 18
+    value: 12.131391272590763
+  - analyte: throat_swab
+    time: 19
+    value: 40.07933341066387
+  - analyte: throat_swab
+    time: 20
+    value: 21.194082920636
+  - analyte: throat_swab
+    time: 21
+    value: negative
+  - analyte: throat_swab
+    time: 22
+    value: negative
   - analyte: stool
     time: 6
-    value: 1212230.4535989882
+    value: 1261466.557704994
   - analyte: stool
     time: 7
-    value: 1119458.9204266046
+    value: 1075775.586026055
   - analyte: stool
     time: 8
-    value: 5963742.971062912
+    value: 6208034.192953503
   - analyte: stool
     time: 9
-    value: 4005307.0120203197
+    value: 4167596.083302621
   - analyte: stool
     time: 10
-    value: 50070.77432939977
+    value: 48117.25968282972
   - analyte: stool
     time: 11
-    value: 120280.27285630006
+    value: 125201.11543965063
   - analyte: stool
     time: 12
-    value: 592099.8987815132
+    value: 615965.2119439708
   - analyte: stool
     time: 13
-    value: 19254.42746485871
+    value: 20035.997805328574
   - analyte: stool
     time: 14
-    value: 74576.3015684785
+    value: 77621.68405893812
   - analyte: stool
     time: 15
-    value: 4587.926940063876
+    value: 4408.484060910738
   - analyte: stool
     time: 16
-    value: 54220.10046069941
+    value: 52117.043090194544
   - analyte: stool
     time: 17
-    value: 54220.10046069941
+    value: 56441.8982747019
   - analyte: stool
     time: 18
-    value: 12923.48459144199
+    value: 12422.303471167794
   - analyte: stool
     time: 19
-    value: 222.21258418470345
+    value: 213.60555581435685
   - analyte: stool
     time: 20
+    value: negative
+  - analyte: stool
+    time: 22
     value: negative
   - analyte: stool
     time: 23
     value: negative
-  - analyte: throat_swab
-    time: 3
-    value: 1539520.713209967
-  - analyte: throat_swab
-    time: 5
-    value: 17772.847089192706
-  - analyte: throat_swab
-    time: 6
-    value: 6832.346427033285
-  - analyte: throat_swab
-    time: 7
-    value: 3336.155215258841
-  - analyte: throat_swab
-    time: 8
-    value: 282.20778901619076
-  - analyte: throat_swab
-    time: 9
-    value: 57.36345073021987
-  - analyte: throat_swab
-    time: 10
-    value: negative
-  - analyte: throat_swab
-    time: 11
-    value: 41.70563565034082
-  - analyte: throat_swab
-    time: 12
-    value: 30.32174708559958
-  - analyte: throat_swab
-    time: 13
-    value: 161.5840185139515
-  - analyte: throat_swab
-    time: 14
-    value: negative
-  - analyte: throat_swab
-    time: 15
-    value: negative
-  - analyte: throat_swab
-    time: 16
-    value: 3.8214479536553294
-  - analyte: throat_swab
-    time: 17
-    value: negative
-  - analyte: throat_swab
-    time: 18
-    value: 12.626342081143548
-  - analyte: throat_swab
-    time: 19
-    value: 41.70563565034082
-  - analyte: throat_swab
-    time: 20
-    value: 22.052008081318615
-  - analyte: throat_swab
-    time: 21
-    value: negative
-  - analyte: throat_swab
-    time: 22
-    value: negative
 - measurements:
   - analyte: sputum
     time: 4
-    value: 8664904.869505715
+    value: 8325456.643763932
   - analyte: sputum
     time: 6
-    value: 732969.0520380974
+    value: 704261.5472214862
   - analyte: sputum
     time: 7
-    value: 2839816.357004413
+    value: 2728591.9587569167
   - analyte: sputum
     time: 8
-    value: 45078.4530610939
+    value: 43326.318556439335
   - analyte: sputum
     time: 9
-    value: 161335.153299529
+    value: 155015.5650154845
   - analyte: sputum
     time: 10
-    value: 25810.55948316664
+    value: 24799.77806285353
   - analyte: sputum
     time: 11
-    value: 97.65546668707512
+    value: 93.83068749279448
   - analyte: sputum
     time: 12
     value: negative
   - analyte: sputum
     time: 13
-    value: 1154.4489176968927
+    value: 1201.1578523132223
   - analyte: sputum
     time: 14
     value: negative
-  - analyte: sputum
-    time: 19
-    value: negative
-  - analyte: throat_swab
-    time: 4
-    value: 2839842.9974452388
-  - analyte: throat_swab
-    time: 5
-    value: 100001.40715982752
-  - analyte: throat_swab
-    time: 6
-    value: 660.8072524437216
-  - analyte: throat_swab
-    time: 7
-    value: 4129.257272806955
-  - analyte: throat_swab
-    time: 8
-    value: 27.285919587568863
-  - analyte: throat_swab
-    time: 9
-    value: 23.269474814361033
-  - analyte: throat_swab
-    time: 10
-    value: negative
-  - analyte: throat_swab
-    time: 11
-    value: negative
-  - analyte: throat_swab
-    time: 12
-    value: 21.48867097710568
-  - analyte: throat_swab
-    time: 13
-    value: 37.53004668707056
-  - analyte: throat_swab
-    time: 14
-    value: negative
-  - analyte: throat_swab
-    time: 19
-    value: negative
-  - analyte: stool
-    time: 7
-    value: 1182176.2639584094
-  - analyte: stool
-    time: 8
-    value: 16387488.870858755
-  - analyte: stool
-    time: 9
-    value: 33571477.44513852
-  - analyte: stool
-    time: 10
-    value: 387443.77945409174
-  - analyte: stool
-    time: 11
-    value: 25810.801613148353
-  - analyte: stool
-    time: 12
-    value: 148943.51854277684
-  - analyte: stool
-    time: 14
-    value: 72704.88040018399
-  - analyte: stool
-    time: 15
-    value: 17329.41721662663
-  - analyte: stool
-    time: 16
-    value: 9160.157441983756
-  - analyte: stool
-    time: 19
-    value: 3521.4040130860444
-  - analyte: stool
-    time: 20
-    value: 3521.4040130860444
-- measurements:
-  - analyte: sputum
-    time: 4
-    value: 398311.8816137271
-  - analyte: sputum
-    time: 6
-    value: 5840.626437523817
-  - analyte: sputum
-    time: 7
-    value: 19755181.735830072
-  - analyte: sputum
-    time: 8
-    value: 7594408.358633062
-  - analyte: sputum
-    time: 9
-    value: 1671101.6506033153
-  - analyte: sputum
-    time: 10
-    value: 8223770.293633364
-  - analyte: sputum
-    time: 11
-    value: 16842035.173609644
-  - analyte: sputum
-    time: 12
-    value: 141403.17236156575
-  - analyte: sputum
-    time: 13
-    value: 141403.17236156575
-  - analyte: sputum
-    time: 14
-    value: 8033.372451610779
   - analyte: sputum
     time: 15
-    value: 22628.825389597063
+    value: negative
   - analyte: sputum
     time: 16
-    value: 1392.1235691333984
+    value: negative
   - analyte: sputum
     time: 17
     value: negative
   - analyte: sputum
     time: 18
-    value: 26534.81486004811
+    value: negative
   - analyte: sputum
     time: 19
-    value: 359.31319652794474
+    value: negative
+  - analyte: throat_swab
+    time: 4
+    value: 2728591.9587569167
+  - analyte: throat_swab
+    time: 5
+    value: 104077.23252028598
+  - analyte: throat_swab
+    time: 6
+    value: 687.7434488855441
+  - analyte: throat_swab
+    time: 7
+    value: 3968.7217628337103
+  - analyte: throat_swab
+    time: 8
+    value: 28.39842997445236
+  - analyte: throat_swab
+    time: 9
+    value: 22.357786718257984
+  - analyte: throat_swab
+    time: 10
+    value: negative
+  - analyte: throat_swab
+    time: 11
+    value: negative
+  - analyte: throat_swab
+    time: 12
+    value: 22.357786718257984
+  - analyte: throat_swab
+    time: 13
+    value: 39.05858508211667
+  - analyte: throat_swab
+    time: 14
+    value: negative
+  - analyte: throat_swab
+    time: 15
+    value: negative
+  - analyte: throat_swab
+    time: 16
+    value: negative
+  - analyte: throat_swab
+    time: 17
+    value: negative
+  - analyte: throat_swab
+    time: 18
+    value: negative
+  - analyte: throat_swab
+    time: 19
+    value: negative
+  - analyte: stool
+    time: 7
+    value: 1135864.4300308404
+  - analyte: stool
+    time: 8
+    value: 17055564.897049055
+  - analyte: stool
+    time: 9
+    value: 32256161.280958217
+  - analyte: stool
+    time: 10
+    value: 372380.90479858284
+  - analyte: stool
+    time: 11
+    value: 26854.727223887174
+  - analyte: stool
+    time: 12
+    value: 143107.9750279164
+  - analyte: stool
+    time: 14
+    value: 75668.87250203495
+  - analyte: stool
+    time: 15
+    value: 18035.977850959003
+  - analyte: stool
+    time: 16
+    value: 9533.54892548039
+  - analyte: stool
+    time: 19
+    value: 3383.436906139621
+  - analyte: stool
+    time: 20
+    value: 3663.8626248378096
+- measurements:
+  - analyte: sputum
+    time: 4
+    value: 414419.7812609166
+  - analyte: sputum
+    time: 6
+    value: 6076.880828671125
+  - analyte: sputum
+    time: 7
+    value: 20554185.984823782
+  - analyte: sputum
+    time: 8
+    value: 7296965.3575560525
+  - analyte: sputum
+    time: 9
+    value: 1739228.1926802045
+  - analyte: sputum
+    time: 10
+    value: 7901603.544301117
+  - analyte: sputum
+    time: 11
+    value: 17523298.52920764
+  - analyte: sputum
+    time: 12
+    value: 147123.64622854357
+  - analyte: sputum
+    time: 13
+    value: 147123.64622854357
+  - analyte: sputum
+    time: 14
+    value: 8358.323813886054
+  - analyte: sputum
+    time: 15
+    value: 23544.27588564792
+  - analyte: sputum
+    time: 16
+    value: 1337.5870355334946
+  - analyte: sputum
+    time: 17
+    value: negative
+  - analyte: sputum
+    time: 18
+    value: 25495.19213400068
+  - analyte: sputum
+    time: 19
+    value: 345.2370781072693
   - analyte: sputum
     time: 20
-    value: 179606.7430027715
+    value: 186870.1150631953
   - analyte: sputum
     time: 21
     value: negative
   - analyte: sputum
     time: 22
-    value: 3088.2384029843124
+    value: 2967.2425398464493
   - analyte: sputum
     time: 23
-    value: 138.13003488903107
+    value: 143.71607146730625
   - analyte: sputum
     time: 24
     value: negative
   - analyte: sputum
     time: 25
-    value: 108.7820016403357
+    value: 113.1482818895981
   - analyte: sputum
     time: 26
-    value: 11961.37185138524
+    value: 12449.123186854498
   - analyte: sputum
     time: 27
-    value: 4246.380630541784
-  - analyte: stool
-    time: 6
-    value: 50183.45966318529
-  - analyte: stool
-    time: 8
-    value: 627.3476427205834
-  - analyte: stool
-    time: 9
-    value: 934.3848870579203
-  - analyte: stool
-    time: 12
-    value: 19291.83394147121
-  - analyte: stool
-    time: 20
-    value: 359.20198008519617
-  - analyte: stool
-    time: 21
-    value: 862.8767758684482
-  - analyte: stool
-    time: 26
-    value: negative
+    value: 4081.3107917677044
   - analyte: throat_swab
     time: 4
-    value: 607311951.692869
+    value: 583520465.5105487
   - analyte: throat_swab
     time: 5
-    value: 431320.6855531491
+    value: 414419.7812609166
   - analyte: throat_swab
     time: 6
-    value: 267427.29196398304
+    value: 256949.60475351932
   - analyte: throat_swab
     time: 7
-    value: 494.05947413358155
+    value: 474.8494125087927
   - analyte: throat_swab
     time: 8
-    value: 87672.74263990784
+    value: 84238.15710397481
   - analyte: throat_swab
     time: 9
-    value: 1767.692930093415
+    value: 1698.977284380004
   - analyte: throat_swab
     time: 10
-    value: 863.1439405581297
+    value: 898.0540560519331
   - analyte: throat_swab
     time: 11
-    value: 18.845275186577894
+    value: 18.111936939086927
   - analyte: throat_swab
     time: 12
     value: negative
   - analyte: throat_swab
     time: 13
-    value: 38.60632756837744
+    value: 37.0937481243148
   - analyte: throat_swab
     time: 14
-    value: 62.26629881786639
+    value: 59.82757365169997
   - analyte: throat_swab
     time: 15
-    value: 35.65196759321473
+    value: 37.0937481243148
   - analyte: throat_swab
     time: 16
-    value: 38.60632756837744
+    value: 37.0937481243148
   - analyte: throat_swab
     time: 17
-    value: 38.60632756837744
+    value: 37.0937481243148
   - analyte: throat_swab
     time: 18
     value: negative
   - analyte: throat_swab
     time: 19
-    value: 53.10054775348839
+    value: 55.24847447218598
   - analyte: throat_swab
     time: 20
     value: negative
   - analyte: throat_swab
     time: 21
+    value: negative
+  - analyte: throat_swab
+    time: 22
+    value: negative
+  - analyte: throat_swab
+    time: 23
+    value: negative
+  - analyte: throat_swab
+    time: 24
+    value: negative
+  - analyte: throat_swab
+    time: 25
     value: negative
   - analyte: throat_swab
     time: 26
@@ -716,100 +760,100 @@ participants:
   - analyte: throat_swab
     time: 27
     value: negative
+  - analyte: stool
+    time: 6
+    value: 48232.90090910245
+  - analyte: stool
+    time: 8
+    value: 602.9635439642443
+  - analyte: stool
+    time: 9
+    value: 972.4864929746473
+  - analyte: stool
+    time: 12
+    value: 18541.727247290793
+  - analyte: stool
+    time: 20
+    value: 373.8509871102169
+  - analyte: stool
+    time: 21
+    value: 898.0540560519331
+  - analyte: stool
+    time: 26
+    value: negative
 - measurements:
   - analyte: sputum
     time: 6
-    value: 76351973.38810533
+    value: 73382905.39596297
+  - analyte: sputum
+    time: 7
+    value: 28201443.35424947
   - analyte: sputum
     time: 8
-    value: 9622591.489304192
+    value: 10011827.047832508
   - analyte: sputum
     time: 9
-    value: 246432.3767989757
+    value: 256400.6108167481
   - analyte: sputum
     time: 10
-    value: 813984.1060862745
+    value: 782327.3692274326
   - analyte: sputum
     time: 11
-    value: 641039.5858845599
+    value: 666966.6241545144
   - analyte: sputum
     time: 13
-    value: 331.0036617897847
+    value: 344.49298729388886
   - analyte: sputum
     time: 14
-    value: 3080.671833159446
+    value: 2959.958541281922
   - analyte: sputum
     time: 16
-    value: 3080.671833159446
+    value: 3206.2479090331585
   - analyte: sputum
     time: 18
-    value: 39424.68348731622
+    value: 37891.41419917017
   - analyte: sputum
     time: 19
-    value: 367041.60959967657
+    value: 352661.0759212832
   - analyte: sputum
     time: 20
-    value: 282.279115398532
+    value: 271.2208122400973
   - analyte: sputum
     time: 21
-    value: 20845.849819946638
+    value: 21695.783587935526
   - analyte: sputum
     time: 22
-    value: 1504.2562994802292
-  - analyte: stool
-    time: 6
-    value: 8013.57692185778
-  - analyte: stool
-    time: 8
-    value: 6309.03483783254
-  - analyte: stool
-    time: 9
-    value: 11935.59146024406
-  - analyte: stool
-    time: 13
-    value: 17777.03972841694
-  - analyte: stool
-    time: 16
-    value: negative
-  - analyte: stool
-    time: 18
-    value: 39423.94380838179
-  - analyte: stool
-    time: 21
-    value: negative
-  - analyte: stool
-    time: 22
-    value: 358.42779066442256
+    value: 1445.3269586958197
   - analyte: throat_swab
     time: 6
-    value: 12924.896721120052
+    value: 13451.62243175235
   - analyte: throat_swab
     time: 7
-    value: 5826.316173226288
+    value: 5599.776862489599
   - analyte: throat_swab
     time: 8
-    value: 4237.268139523922
+    value: 4408.645719992577
   - analyte: throat_swab
     time: 9
-    value: 3080.6862830838218
+    value: 2959.958541281922
   - analyte: throat_swab
     time: 10
-    value: 41.703468036512966
+    value: 43.40361181227624
   - analyte: throat_swab
     time: 11
-    value: 117.50833957235712
+    value: 122.29885416335843
   - analyte: throat_swab
     time: 12
-    value: 92.51351990840905
+    value: 88.91515034335782
   - analyte: throat_swab
     time: 13
-    value: 45.17327798806515
+    value: 43.40361181227624
   - analyte: throat_swab
     time: 14
-    value: 305.67208057605825
+    value: 318.03657127918655
   - analyte: throat_swab
     time: 15
-    value: 57.360467452822306
+    value: 55.129397220885465
   - analyte: throat_swab
     time: 16
     value: negative
@@ -818,62 +862,86 @@ participants:
     value: negative
   - analyte: throat_swab
     time: 18
-    value: 16.036792042467546
+    value: 16.685248380294652
   - analyte: throat_swab
     time: 19
-    value: 38.511917883415215
+    value: 37.01449428451262
   - analyte: throat_swab
     time: 20
     value: negative
   - analyte: throat_swab
     time: 21
     value: negative
+  - analyte: stool
+    time: 6
+    value: 7699.644511873252
+  - analyte: stool
+    time: 8
+    value: 6063.7833038530725
+  - analyte: stool
+    time: 9
+    value: 12422.291543368332
+  - analyte: stool
+    time: 13
+    value: 17080.8633639578
+  - analyte: stool
+    time: 16
+    value: negative
+  - analyte: stool
+    time: 18
+    value: 37891.41419917017
+  - analyte: stool
+    time: 21
+    value: negative
+  - analyte: stool
+    time: 22
+    value: 373.04522462778885
 - measurements:
   - analyte: sputum
     time: 4
-    value: 12814549.385884618
+    value: 13337028.360774042
   - analyte: sputum
     time: 6
-    value: 3581588.987016199
+    value: 3442345.491985797
   - analyte: sputum
     time: 7
-    value: 529299.6162572922
+    value: 508726.5029854609
   - analyte: sputum
     time: 8
-    value: 788346.3787934828
+    value: 820496.7907660429
   - analyte: sputum
     time: 11
-    value: 151489140.04694122
+    value: 145550446.6058504
   - analyte: sputum
     time: 12
-    value: 30070.618849728777
+    value: 28892.871394953585
   - analyte: sputum
     time: 13
-    value: 788346.3787934828
+    value: 820496.7907660429
   - analyte: sputum
     time: 14
-    value: 48499.2350855691
+    value: 50477.135194327704
   - analyte: sputum
     time: 17
-    value: 17217.608065550165
+    value: 16543.26231370986
   - analyte: sputum
     time: 18
-    value: 119265814.56611462
+    value: 114594643.33918037
   - analyte: sputum
     time: 19
-    value: 99355.73348745477
+    value: 95464.36155337644
   - analyte: sputum
     time: 20
-    value: 136614.55150623788
+    value: 142185.97826803022
   - analyte: sputum
     time: 21
-    value: 296.04583961364955
+    value: 308.02383669431777
   - analyte: sputum
     time: 22
-    value: 606.2930098660331
+    value: 582.7272743453912
   - analyte: sputum
     time: 23
-    value: 113.80829468479037
+    value: 109.35087297135178
   - analyte: sputum
     time: 24
     value: negative
@@ -882,82 +950,61 @@ participants:
     value: negative
   - analyte: sputum
     time: 26
-    value: 1456.8841823384566
+    value: 1515.829629792457
   - analyte: sputum
     time: 27
     value: negative
   - analyte: sputum
     time: 28
     value: negative
-  - analyte: stool
-    time: 6
-    value: 4443.981815784081
-  - analyte: stool
-    time: 18
-    value: 407.19795023417413
-  - analyte: stool
-    time: 19
-    value: negative
-  - analyte: stool
-    time: 20
-    value: 5.512267443579327
-  - analyte: stool
-    time: 23
-    value: 105.0995761887353
-  - analyte: stool
-    time: 24
-    value: negative
-  - analyte: stool
-    time: 26
-    value: 89.62866221751295
   - analyte: throat_swab
     time: 4
-    value: 728028.1968528272
+    value: 757711.5992517561
   - analyte: throat_swab
     time: 7
-    value: 15900.100389738018
+    value: 15277.21289729626
   - analyte: throat_swab
     time: 8
-    value: 3498.7331970270075
+    value: 3641.350525066505
   - analyte: throat_swab
     time: 9
-    value: 3230.9765092416715
+    value: 3362.6793887576005
   - analyte: throat_swab
     time: 10
-    value: 58237205.59781828
+    value: 55955759.18726219
   - analyte: throat_swab
     time: 11
-    value: 488801.69375349645
+    value: 469793.8620102167
   - analyte: throat_swab
     time: 12
-    value: 4812.262379932128
+    value: 5008.422522418584
   - analyte: throat_swab
     time: 13
-    value: 12518.100067838337
+    value: 13028.369895021267
   - analyte: throat_swab
     time: 14
-    value: 2169.273088069151
+    value: 2084.9370105479534
   - analyte: throat_swab
     time: 15
-    value: 23674.72770070666
+    value: 22754.0982379742
   - analyte: throat_swab
     time: 16
-    value: 144.51371505992313
+    value: 138.89406926990839
   - analyte: throat_swab
     time: 17
-    value: 711.1727895806031
+    value: 683.3125481521544
   - analyte: throat_swab
     time: 18
-    value: 9.630177117856427
+    value: 9.252914287454043
   - analyte: throat_swab
     time: 19
-    value: 34.445097790442105
+    value: 33.10564534674472
   - analyte: throat_swab
     time: 20
-    value: 606.3043852416088
+    value: 631.0189051927977
   - analyte: throat_swab
     time: 21
-    value: 34.445097790442105
+    value: 33.10564534674472
   - analyte: throat_swab
     time: 22
     value: negative
@@ -966,129 +1013,177 @@ participants:
     value: negative
   - analyte: throat_swab
     time: 24
-    value: 15.531979115181876
+    value: 16.16025046730857
   - analyte: throat_swab
     time: 25
     value: negative
   - analyte: throat_swab
     time: 26
-    value: 13.241658267844254
+    value: 12.722796069597907
   - analyte: throat_swab
     time: 27
     value: negative
   - analyte: throat_swab
     time: 28
     value: negative
+  - analyte: stool
+    time: 6
+    value: 4623.741680481508
+  - analyte: stool
+    time: 18
+    value: 391.2459433957464
+  - analyte: stool
+    time: 19
+    value: negative
+  - analyte: stool
+    time: 20
+    value: 5.736961585707858
+  - analyte: stool
+    time: 23
+    value: 109.35087297135178
+  - analyte: stool
+    time: 24
+    value: negative
+  - analyte: stool
+    time: 26
+    value: 93.25415774407219
 - measurements:
   - analyte: sputum
     time: 2
-    value: 2483609.7518102843
+    value: 2584872.296288066
   - analyte: sputum
     time: 3
-    value: 17777.123111813038
+    value: 17085.831388999915
   - analyte: sputum
     time: 4
-    value: 54241.91611454683
+    value: 52116.985435767456
   - analyte: sputum
     time: 5
-    value: 11022.216997791265
+    value: 11471.510798939711
   - analyte: sputum
     time: 6
-    value: 1389.1231198057637
+    value: 1445.2998417272092
   - analyte: sputum
     time: 7
-    value: 420.42658641637445
+    value: 403.952557377349
   - analyte: sputum
     time: 8
-    value: 626.1893392130044
+    value: 651.714420828613
   - analyte: sputum
     time: 9
+    value: negative
+  - analyte: sputum
+    time: 10
+    value: negative
+  - analyte: sputum
+    time: 11
+    value: negative
+  - analyte: sputum
+    time: 12
+    value: negative
+  - analyte: sputum
+    time: 13
     value: negative
   - analyte: sputum
     time: 14
     value: negative
-  - analyte: stool
-    time: 3
-    value: 50090.33351784344
-  - analyte: stool
-    time: 4
-    value: 22579.735661503637
-  - analyte: stool
-    time: 5
-    value: 4238.480682198356
-  - analyte: stool
-    time: 8
-    value: 10181.65153295411
-  - analyte: stool
-    time: 9
-    value: 534.0077315458201
-  - analyte: stool
-    time: 12
-    value: negative
   - analyte: throat_swab
     time: 2
-    value: 11935.535476486382
+    value: 12422.175010403982
   - analyte: throat_swab
     time: 3
-    value: 102583.50231626267
+    value: 106766.07023314988
   - analyte: throat_swab
     time: 5
-    value: 194011.81120980292
+    value: 201920.22964718397
   - analyte: throat_swab
     time: 6
-    value: 54225.12688159792
+    value: 56435.48196526866
   - analyte: throat_swab
     time: 7
-    value: 80763.6754377411
+    value: 77623.77957581503
   - analyte: throat_swab
     time: 8
-    value: 240.64791498186997
+    value: 231.29210758037064
   - analyte: throat_swab
     time: 9
-    value: 67.28046058737921
+    value: 70.0236414062469
   - analyte: throat_swab
     time: 10
     value: negative
   - analyte: throat_swab
     time: 11
-    value: 18.804481486221412
+    value: 18.073408843919893
   - analyte: throat_swab
     time: 12
-    value: 8.476769360148438
+    value: 8.147213122246047
   - analyte: throat_swab
     time: 13
     value: negative
   - analyte: throat_swab
+    time: 14
+    value: negative
+  - analyte: throat_swab
     time: 15
+    value: negative
+  - analyte: stool
+    time: 3
+    value: 48128.49285522511
+  - analyte: stool
+    time: 4
+    value: 21695.376535483443
+  - analyte: stool
+    time: 5
+    value: 4072.4761227139
+  - analyte: stool
+    time: 8
+    value: 9782.876428315534
+  - analyte: stool
+    time: 9
+    value: 513.09275637349
+  - analyte: stool
+    time: 12
     value: negative
 - measurements:
   - analyte: sputum
     time: 8
-    value: 108302.23613721151
+    value: 112707.96415611677
   - analyte: sputum
     time: 9
-    value: 57257.43082142817
+    value: 59577.421646068055
   - analyte: sputum
     time: 10
     value: negative
   - analyte: sputum
     time: 11
-    value: 443.7760967535199
+    value: 426.3628829076596
   - analyte: sputum
     time: 12
+    value: negative
+  - analyte: sputum
+    time: 10
     value: negative
   - analyte: throat_swab
     time: 8
-    value: 4842.9876951504575
+    value: 5040.781602099776
   - analyte: throat_swab
     time: 9
-    value: 908.8017755649098
+    value: 873.4041253126768
   - analyte: throat_swab
     time: 10
-    value: 7.043705924226177
+    value: 6.7693549650961105
   - analyte: throat_swab
     time: 11
     value: negative
   - analyte: throat_swab
     time: 12
+    value: negative
+  - analyte: stool
+    time: 8
+    value: negative
+  - analyte: stool
+    time: 9
+    value: negative
+  - analyte: stool
+    time: 10
     value: negative

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,9 @@
 black
+matplotlib
+jupyter
+jupytext
 jsonschema
 pip-tools
 pyaml
+pymupdf
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,59 +4,396 @@
 #
 #    pip-compile
 #
+anyio==4.4.0
+    # via
+    #   httpx
+    #   jupyter-server
+appnope==0.1.4
+    # via ipykernel
+argon2-cffi==23.1.0
+    # via jupyter-server
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
+arrow==1.3.0
+    # via isoduration
+asttokens==2.4.1
+    # via stack-data
+async-lru==2.0.4
+    # via jupyterlab
 attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
+babel==2.15.0
+    # via jupyterlab-server
+beautifulsoup4==4.12.3
+    # via nbconvert
 black==24.4.2
     # via -r requirements.in
+bleach==6.1.0
+    # via nbconvert
 build==1.2.1
     # via pip-tools
+certifi==2024.7.4
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==1.16.0
+    # via argon2-cffi-bindings
+charset-normalizer==3.3.2
+    # via requests
 click==8.1.7
     # via
     #   black
     #   pip-tools
+comm==0.2.2
+    # via
+    #   ipykernel
+    #   ipywidgets
+contourpy==1.2.1
+    # via matplotlib
+cycler==0.12.1
+    # via matplotlib
+debugpy==1.8.2
+    # via ipykernel
+decorator==5.1.1
+    # via ipython
+defusedxml==0.7.1
+    # via nbconvert
+executing==2.0.1
+    # via stack-data
+fastjsonschema==2.20.0
+    # via nbformat
+fonttools==4.53.1
+    # via matplotlib
+fqdn==1.5.1
+    # via jsonschema
+h11==0.14.0
+    # via httpcore
+httpcore==1.0.5
+    # via httpx
+httpx==0.27.0
+    # via jupyterlab
+idna==3.7
+    # via
+    #   anyio
+    #   httpx
+    #   jsonschema
+    #   requests
 iniconfig==2.0.0
     # via pytest
-jsonschema==4.23.0
-    # via -r requirements.in
+ipykernel==6.29.5
+    # via
+    #   jupyter
+    #   jupyter-console
+    #   jupyterlab
+    #   qtconsole
+ipython==8.26.0
+    # via
+    #   ipykernel
+    #   ipywidgets
+    #   jupyter-console
+ipywidgets==8.1.3
+    # via jupyter
+isoduration==20.11.0
+    # via jsonschema
+jedi==0.19.1
+    # via ipython
+jinja2==3.1.4
+    # via
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
+    #   nbconvert
+json5==0.9.25
+    # via jupyterlab-server
+jsonpointer==3.0.0
+    # via jsonschema
+jsonschema[format-nongpl]==4.23.0
+    # via
+    #   -r requirements.in
+    #   jupyter-events
+    #   jupyterlab-server
+    #   nbformat
 jsonschema-specifications==2023.12.1
     # via jsonschema
+jupyter==1.0.0
+    # via -r requirements.in
+jupyter-client==8.6.2
+    # via
+    #   ipykernel
+    #   jupyter-console
+    #   jupyter-server
+    #   nbclient
+    #   qtconsole
+jupyter-console==6.6.3
+    # via jupyter
+jupyter-core==5.7.2
+    # via
+    #   ipykernel
+    #   jupyter-client
+    #   jupyter-console
+    #   jupyter-server
+    #   jupyterlab
+    #   nbclient
+    #   nbconvert
+    #   nbformat
+    #   qtconsole
+jupyter-events==0.10.0
+    # via jupyter-server
+jupyter-lsp==2.2.5
+    # via jupyterlab
+jupyter-server==2.14.2
+    # via
+    #   jupyter-lsp
+    #   jupyterlab
+    #   jupyterlab-server
+    #   notebook
+    #   notebook-shim
+jupyter-server-terminals==0.5.3
+    # via jupyter-server
+jupyterlab==4.2.4
+    # via notebook
+jupyterlab-pygments==0.3.0
+    # via nbconvert
+jupyterlab-server==2.27.3
+    # via
+    #   jupyterlab
+    #   notebook
+jupyterlab-widgets==3.0.11
+    # via ipywidgets
+jupytext==1.16.4
+    # via -r requirements.in
+kiwisolver==1.4.5
+    # via matplotlib
+markdown-it-py==3.0.0
+    # via
+    #   jupytext
+    #   mdit-py-plugins
+markupsafe==2.1.5
+    # via
+    #   jinja2
+    #   nbconvert
+matplotlib==3.9.1
+    # via -r requirements.in
+matplotlib-inline==0.1.7
+    # via
+    #   ipykernel
+    #   ipython
+mdit-py-plugins==0.4.1
+    # via jupytext
+mdurl==0.1.2
+    # via markdown-it-py
+mistune==3.0.2
+    # via nbconvert
 mypy-extensions==1.0.0
     # via black
+nbclient==0.10.0
+    # via nbconvert
+nbconvert==7.16.4
+    # via
+    #   jupyter
+    #   jupyter-server
+nbformat==5.10.4
+    # via
+    #   jupyter-server
+    #   jupytext
+    #   nbclient
+    #   nbconvert
+nest-asyncio==1.6.0
+    # via ipykernel
+notebook==7.2.1
+    # via jupyter
+notebook-shim==0.2.4
+    # via
+    #   jupyterlab
+    #   notebook
+numpy==2.0.1
+    # via
+    #   contourpy
+    #   matplotlib
+overrides==7.7.0
+    # via jupyter-server
 packaging==24.1
     # via
     #   black
     #   build
+    #   ipykernel
+    #   jupyter-server
+    #   jupyterlab
+    #   jupyterlab-server
+    #   jupytext
+    #   matplotlib
+    #   nbconvert
     #   pytest
+    #   qtconsole
+    #   qtpy
+pandocfilters==1.5.1
+    # via nbconvert
+parso==0.8.4
+    # via jedi
 pathspec==0.12.1
     # via black
+pexpect==4.9.0
+    # via ipython
+pillow==10.4.0
+    # via matplotlib
 pip-tools==7.4.1
     # via -r requirements.in
 platformdirs==4.2.2
-    # via black
+    # via
+    #   black
+    #   jupyter-core
 pluggy==1.5.0
     # via pytest
+prometheus-client==0.20.0
+    # via jupyter-server
+prompt-toolkit==3.0.47
+    # via
+    #   ipython
+    #   jupyter-console
+psutil==6.0.0
+    # via ipykernel
+ptyprocess==0.7.0
+    # via
+    #   pexpect
+    #   terminado
+pure-eval==0.2.3
+    # via stack-data
 pyaml==24.7.0
     # via -r requirements.in
+pycparser==2.22
+    # via cffi
+pygments==2.18.0
+    # via
+    #   ipython
+    #   jupyter-console
+    #   nbconvert
+    #   qtconsole
+pymupdf==1.24.9
+    # via -r requirements.in
+pymupdfb==1.24.9
+    # via pymupdf
+pyparsing==3.1.2
+    # via matplotlib
 pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
 pytest==8.3.2
     # via -r requirements.in
+python-dateutil==2.9.0.post0
+    # via
+    #   arrow
+    #   jupyter-client
+    #   matplotlib
+python-json-logger==2.0.7
+    # via jupyter-events
 pyyaml==6.0.1
-    # via pyaml
+    # via
+    #   jupyter-events
+    #   jupytext
+    #   pyaml
+pyzmq==26.0.3
+    # via
+    #   ipykernel
+    #   jupyter-client
+    #   jupyter-console
+    #   jupyter-server
+    #   qtconsole
+qtconsole==5.5.2
+    # via jupyter
+qtpy==2.4.1
+    # via qtconsole
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
+    #   jupyter-events
+requests==2.32.3
+    # via jupyterlab-server
+rfc3339-validator==0.1.4
+    # via
+    #   jsonschema
+    #   jupyter-events
+rfc3986-validator==0.1.1
+    # via
+    #   jsonschema
+    #   jupyter-events
 rpds-py==0.19.1
     # via
     #   jsonschema
     #   referencing
+send2trash==1.8.3
+    # via jupyter-server
+six==1.16.0
+    # via
+    #   asttokens
+    #   bleach
+    #   python-dateutil
+    #   rfc3339-validator
+sniffio==1.3.1
+    # via
+    #   anyio
+    #   httpx
+soupsieve==2.5
+    # via beautifulsoup4
+stack-data==0.6.3
+    # via ipython
+terminado==0.18.1
+    # via
+    #   jupyter-server
+    #   jupyter-server-terminals
+tinycss2==1.3.0
+    # via nbconvert
+tornado==6.4.1
+    # via
+    #   ipykernel
+    #   jupyter-client
+    #   jupyter-server
+    #   jupyterlab
+    #   notebook
+    #   terminado
+traitlets==5.14.3
+    # via
+    #   comm
+    #   ipykernel
+    #   ipython
+    #   ipywidgets
+    #   jupyter-client
+    #   jupyter-console
+    #   jupyter-core
+    #   jupyter-events
+    #   jupyter-server
+    #   jupyterlab
+    #   matplotlib-inline
+    #   nbclient
+    #   nbconvert
+    #   nbformat
+    #   qtconsole
+types-python-dateutil==2.9.0.20240316
+    # via arrow
+typing-extensions==4.12.2
+    # via ipython
+uri-template==1.3.0
+    # via jsonschema
+urllib3==2.2.2
+    # via requests
+wcwidth==0.2.13
+    # via prompt-toolkit
+webcolors==24.6.0
+    # via jsonschema
+webencodings==0.5.1
+    # via
+    #   bleach
+    #   tinycss2
+websocket-client==1.8.0
+    # via jupyter-server
 wheel==0.43.0
     # via pip-tools
+widgetsnbextension==4.0.11
+    # via ipywidgets
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tutorials/woelfel2020-extraction.md
+++ b/tutorials/woelfel2020-extraction.md
@@ -1,0 +1,250 @@
+# Extracting Data From Vector Graphics
+
+When raw data are not available, they can often be extracted from figures in publications. Vector graphics, as are often present in modern PDFs, are particularly suitable for data extraction because each visual element can be accessed programmatically. For rasterized figures, other methods, such as [WebPlotDigitizer](https://automeris.io), may be suitable. Here, we extract viral loads for throat swabs and stool and sputum samples from [one of the early virological analyses conducted to study SARS-CoV-2](https://doi.org/10.1038/s41586-020-2196-x). Unfortunately, there is no "standard" format for these vector graphics, and each extraction is likely to take some time to get right.
+
+The data for nine patients are shown in figure 2 on the third page as a vector graphic. We first download the PDF document, load it using the [`pymupdf`](https://pymupdf.readthedocs.io/en/latest/index.html) library, and extract the third page.
+
+```python
+from bisect import bisect
+import io
+import matplotlib as mpl
+from matplotlib import pyplot as plt
+import numpy as np
+import requests
+import pymupdf
+import yaml
+
+
+# Load the document from Nature and get the page with the figure.
+response = requests.get("https://www.nature.com/articles/s41586-020-2196-x.pdf")
+response.raise_for_status()
+document = pymupdf.Document(stream=response.content)
+page = document[2]
+```
+
+Having obtained the page, we can get all drawings on the page using the [`get_drawings`](https://pymupdf.readthedocs.io/en/latest/page.html#Page.get_drawings) method of the page (see [here](https://pymupdf.readthedocs.io/en/latest/recipes-drawing-and-graphics.html#how-to-extract-drawings) for further details). Each drawing is a vector graphics "path", such as a line or polygon (see [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) for a discussion of paths in the context of SVG files). Before extracting data from the figure, let us first draw all lines and markers in the `drawings` object to verify we have obtained the right information. We also return all lines and markers grouped by their color.
+
+```python
+def draw_lines_and_markers(drawings, alpha=0.7, ax=None):
+    """
+    Draw all lines in the figure that have a color specified.
+
+    Args:
+        drawings: Drawings to plot.
+        ax: Axes to plot into or the default axes.
+
+    Returns:
+        Tuple comprising lines and markers each keyed by color.
+    """
+    ax = ax or plt.gca()
+    ax.set_aspect("equal")
+
+    lines = {}
+    markers = {}
+
+    for drawing in drawings:
+        rect = drawing["rect"]
+
+        # Skip if there is no color.
+        color = drawing["color"]
+        if not color:
+            continue
+
+        # Skip if the drawing doesnt have a size and the color is black.
+        if (not rect.width or not rect.height) and color == (0, 0, 0):
+            continue
+
+        # If all of the kinds are "c", we likely just have marker. If the marker is
+        # black, we don't care about it and drop it.
+        is_marker = all(item[0] == "c" for item in drawing["items"])
+        if is_marker:
+            if color == (0, 0, 0):
+                continue
+            x = (rect.x0 + rect.x1) / 2
+            y = - (rect.y0 + rect.y1) / 2
+            ax.scatter(x, y, color=color, marker=".", alpha=alpha)
+            markers.setdefault(color, []).append((x, y))
+            continue
+
+        for kind, *points in drawing["items"]:
+            # Check we only have lines if the drawing wasn't a marker.
+            assert kind == "l"
+            # Get the line coordinates. We invert the y coordinate because PDF
+            # documents use the convention to measure distance from the top instead
+            # of the bottom of the page.
+            x = [pt.x for pt in points]
+            y = [-pt.y for pt in points]
+
+            # Add the line to the plot and our collection of lines.
+            marker = None if color == (0, 0, 0) else "x"
+            ax.plot(x, y, color=color, alpha=alpha, marker=marker)
+            lines.setdefault(color, []).append((x, y))
+
+    return lines, markers
+
+
+# Get the drawings and plot them.
+fig, ax = plt.subplots()
+drawings = page.get_drawings()
+lines_by_color, markers_by_color = draw_lines_and_markers(drawings)
+fig.tight_layout()
+```
+
+We are able to successfully reproduce the figure in Python and are almost ready to extract the data. However, we need to separate the data by patient. Fortunately, the panels nicely fall into a grid, and we can use divisions along the x and y axes to separate lines capturing data for different patients.
+
+```python
+fig, ax = plt.subplots()
+ax.set_aspect("equal")
+
+# X and Y divisions between different patients. We show the divisions as dotted lines.
+xdivs = [225, 395]
+for xdiv in xdivs:
+    ax.axvline(xdiv, color="magenta")
+ydivs = [-340, -240, -145]
+for ydiv in ydivs:
+    ax.axhline(ydiv, color="magenta")
+
+
+def get_patient_idx(x, y):
+    # Look up the x and y indices for any vertex of the line using the bisect method
+    # (see https://docs.python.org/3/library/bisect.html for details).
+    col = bisect(xdivs, x)
+    row = 3 - bisect(ydivs, y)
+    if row > 2:
+        return None
+    return col + 3 * row
+
+
+# Run over all lines and group them by patient.
+lines_by_patient_and_color = {}
+for color, lines in lines_by_color.items():
+    for line in lines:
+        x, y = line
+        idx = get_patient_idx(x[0], y[0])
+        if idx is None:
+            continue
+        # Save the line by patient and color.
+        lines_by_patient_and_color.setdefault(idx, {}).setdefault(color, []).append(
+            line
+        )
+
+        # Demonstrate that we got the line right.
+        ax.plot(x, y, color=f"C{idx}")
+
+# Do the same for markers.
+markers_by_patient_and_color = {}
+for color, markers in markers_by_color.items():
+    for marker in markers:
+        idx = get_patient_idx(*marker)
+        markers_by_patient_and_color.setdefault(idx, {}).setdefault(color, []).append(
+            marker
+        )
+
+        # Demonstrate that we got the marker right.
+        ax.scatter(*marker, color=f"C{idx}", marker=".")
+```
+
+We now have all the data grouped by patient and color of the lines which allows us to distinguish stool from sputum samples and throat swaps from the lines that represent the axes. The colors are however cumbersome, and we replace them by semantically meaningful keys below.
+
+```python
+kind_by_color = {
+    (0, 0, 0): "axes",
+    (0.9289997816085815, 0.4899977147579193, 0.1919890195131302): "sputum",
+    (1.0, 0.7529869675636292, 0.0): "throat_swab",
+    (0.49799343943595886, 0.49799343943595886, 0.49799343943595886): "stool",
+}
+
+lines_by_patient_and_kind = {
+    patient: {kind_by_color[color]: lines for color, lines in by_color.items()}
+    for patient, by_color in sorted(lines_by_patient_and_color.items())
+}
+markers_by_patient_and_kind = {
+    patient: {kind_by_color[color]: markers for color, markers in by_color.items()}
+    for patient, by_color in sorted(markers_by_patient_and_color.items())
+}
+```
+
+We are finally ready to extract the data for each patient. We obtain the x and y axes by picking the longest horizontal and vertical lines of the `axes` kind, respectively. This allows us to transform from the graphics coordinates to the data coordinates. The y axis has limits from 0 (representing a negative sample) to 10 on the log10 scale. But the x axes of each subplot are not shared, and we manually extract the limits from the figure in the publication.
+
+```python
+fig, ax = plt.subplots()
+
+xlims = [
+    (3.5, 22.5),
+    (2.5, 20.5),
+    (2.5, 23.5),
+    (3.5, 20.5),
+    (3.5, 27.5),
+    (5.5, 22.5),
+    (3.5, 28.5),
+    (1.5, 15.5),
+    (7.5, 12.5),
+]
+
+patients = []
+for patient, lines_by_kind in lines_by_patient_and_kind.items():
+    # Extract the axes.
+    lines = lines_by_kind["axes"]
+    xaxis = max(lines, key=lambda xy: abs(xy[0][0] - xy[0][1]))
+    yaxis = max(lines, key=lambda xy: abs(xy[1][0] - xy[1][1]))
+    ax.plot(*xaxis, color="C0")
+    ax.plot(*yaxis, color="C1")
+
+    # Linear fit from the graphics coordinates to the data coordinates.
+    xinterp = np.polynomial.Polynomial.fit(xaxis[0], xlims[patient], 1)
+    yinterp = np.polynomial.Polynomial.fit(yaxis[1], (0, 10), 1)
+
+    measurements = []
+    for kind, markers in markers_by_patient_and_kind[patient].items():
+        x, y = np.transpose(markers)
+        ax.plot(x, y, marker=".")
+
+        # Transform from graphics to data coordinates.
+        days = xinterp(x)
+        log10s = yinterp(y)
+
+        # Sanity check that the days are close to integers.
+        np.testing.assert_allclose(days, np.round(days), atol=0.05)
+
+        # Store data in the format expected by the schema.
+        measurements.extend({
+            "analyte": kind,
+            "time": round(day),
+            "value": "negative" if log10 < 0.05 else float(10 ** log10)
+        } for day, log10 in zip(days, log10s))
+    patients.append({"measurements": measurements})
+```
+
+Having extracted the data, we can now plot it on regular axes to verify that the extraction worked as expected.
+
+```python
+fig, axes = plt.subplots(3, 3, sharex=True, sharey=True)
+for i, (ax, patient) in enumerate(zip(axes.ravel(), patients)):
+    # For plotting, we need to group the samples by analyte again.
+    xy_by_analyte = {}
+    for measurement in patient["measurements"]:
+        xy_by_analyte.setdefault(measurement["analyte"], []).append(
+            (
+                measurement["time"],
+                0.1 if measurement["value"] == "negative" else measurement["value"],
+            )
+        )
+    for analyte, xy in sorted(xy_by_analyte.items()):
+        ax.plot(*np.transpose(xy), label=analyte, marker=".")
+    ax.set_yscale("log")
+    ax.axhline(1, color="k")
+
+    print(f"patient {i}", {key: len(value) for key, value in xy_by_analyte.items()})
+
+ax.legend(fontsize="small")
+fig.tight_layout()
+```
+
+Finally, we write the data as a YAML file which can be copied into the `data` folder of the repository.
+
+```python
+# Dump the data to YAML in the correct format.
+stream = io.StringIO()
+yaml.dump(patients, stream)
+print(stream.getvalue())
+```


### PR DESCRIPTION
This PR adds a Jupyter notebook illustrating how to extract data from vector graphics in a publication. Specifically, the notebook extracts the data for the Wölfel et al. (2020) dataset. 

A previous version used line paths rather than markers to extract data. If multiple markers fell on a straight line, the PDF optimizer reduced multiple lines to a single line, leading to missing data. This is fixed in the extraction notebook in this PR. 

The change from lines to markers also led to small changes in previously extracted values. Through manual inspection, the updated approach appears to more faithfully reproduce the figure. For example, negative samples on the x-axis have a numerical value of ~1e-15 with the new approach whereas the previous approach had values around ~1e-3 even though they should be zero.