### PR TITLE
Add participant attributes to schema.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Lint code
       run: black --check .
     - name: Run tests
-      run: pytest -vx
+      run: pytest -v

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -91,6 +91,20 @@ properties:
       required:
         - measurements
       properties:
+        attributes:
+          type: object
+          properties:
+            sex:
+              description: Sex of the participant at birth.
+              type: string
+              enum:
+                - female
+                - male
+            age:
+              description: Age of the participant in years.
+              type: number
+              minimum: 0
+              maximum: 120
         measurements:
           type: array
           minItems: 1

--- a/tests/examples/invalid_attributes.yaml
+++ b/tests/examples/invalid_attributes.yaml
@@ -9,7 +9,7 @@ analyte:
   specimen: stool
 participants:
   - attributes:
-      sex: female
-      age: 86
+      sex: xxx
+      age: -1
     measurements:
     - value: 3

--- a/tests/examples/valid_multiple_analytes.yaml
+++ b/tests/examples/valid_multiple_analytes.yaml
@@ -14,9 +14,15 @@ analytes:
     description: Another analyte.
     specimen: sputum
 participants:
-  - measurements:
+  - attributes:
+      sex: female
+      age: 38
+    measurements:
     - value: 3
       analyte: analyte1
-  - measurements:
+  - attributes:
+      sex: male
+      age: 87
+    measurements:
     - value: 1
       analyte: analyte2

--- a/tests/examples/valid_single_analyte.yaml
+++ b/tests/examples/valid_single_analyte.yaml
@@ -11,5 +11,6 @@ participants:
   - attributes:
       sex: female
       age: 86
+      arbitrary_attribute: This is some unstructured text that is not validated.
     measurements:
     - value: 3

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -76,5 +76,5 @@ def test_valid_examples(path: Path) -> None:
     "path", INVALID_EXAMPLE_PATHS, ids=[path.stem for path in INVALID_EXAMPLE_PATHS]
 )
 def test_invalid_examples(path: Path) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises((ValueError, jsonschema.ValidationError)):
         load_and_validate(path)


### PR DESCRIPTION
This PR expands the schema to support participant-level attributes ("option 2" as discussed in #5). Arbitrary attributes can be added for patients, but `age` and `sex` are validated against the schema. I've also added examples to the `tests/examples` section to illustrate how the expanded schema can be used.