### PR TITLE
Add data from Natarajan et al. (2022) and utility functions.

### DIFF
--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -152,6 +152,9 @@ properties:
               value:
                 $ref: "#/$defs/negative_positive_number"
               analyte:
+                description: >
+                  Analyte for which a measurement is reported. The analyte key must
+                  appear in the dictionary of `analytes` metadata.
                 type: string
             required:
               - time

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -62,6 +62,7 @@ $defs:
         enum:
           - symptom onset
           - confirmation date
+          - enrollment
     required:
       - biomarker
       - description

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -158,6 +158,11 @@ properties:
                   Analyte for which a measurement is reported. The analyte key must
                   appear in the dictionary of `analytes` metadata.
                 type: string
+              sample_id:
+                description: >
+                  Unique sample identifier if multiple measurements are reported for the
+                  same sample, e.g., replicates or different analytes.
+                type: [string, integer]
             required:
               - time
               - value

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -144,11 +144,13 @@ properties:
             additionalProperties: false
             properties:
               time:
-                type: number
                 description: >
                   Temporal offset for the sample, e.g., relative to symptom onset, drug
                   ingestion, or hospital admission. The reference event should be
                   defined in the dataset description.
+                oneOf:
+                  - type: number
+                  - const: unknown
               value:
                 $ref: "#/$defs/negative_positive_number"
               analyte:

--- a/data/natarajan2022.yaml
+++ b/data/natarajan2022.yaml
@@ -1,0 +1,30922 @@
+# yaml-language-server: $schema=.schema.yaml
+title: Gastrointestinal symptoms and fecal shedding of SARS-CoV-2 RNA suggest prolonged
+  gastrointestinal infection
+doi: 10.1016/j.medj.2022.04.001
+description: 'Fecal samples were collected from 113 participants "in a randomized
+  controlled study of Peg-interferon lambda-1a versus a placebo control for the treatment
+  of mild to moderate COVID-19." A total of 7,563 measurements were taken for 679
+  samples using seven distinct assays; assays were typically run in duplicates.
+
+
+  Samples were initially collected using OMNIGene GUT collection tubes (OG) but subsequently
+  replaced with Zymo DNA/RNA shield fecal collection tubes (ZY) because of better
+  performance. There are consequently 14 analytes following the naming convention
+  `{target gene E, RdRP, N1, or N2}-{genomic RNA (gRNA) or subgenomic RNA (sgRNA)}-{quantification
+  method RT-qPCR or ddPCR}-{collection tube OG or ZY}`.
+
+
+  The reference event for temporal offsets in days is the day of enrollment.'
+analytes:
+  E-gRNA-RT-qPCR-OG:
+    description: Concentration of genomic RNA of the E gene quantified using RT-qPCR
+      for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  E-gRNA-RT-qPCR-ZY:
+    description: Concentration of genomic RNA of the E gene quantified using RT-qPCR
+      for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  RdRP-gRNA-RT-qPCR-OG:
+    description: Concentration of genomic RNA of the RdRp gene quantified using RT-qPCR
+      for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  RdRP-gRNA-RT-qPCR-ZY:
+    description: Concentration of genomic RNA of the RdRp gene quantified using RT-qPCR
+      for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N1-gRNA-RT-qPCR-OG:
+    description: Concentration of genomic RNA of the N1 gene quantified using RT-qPCR
+      for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N1-gRNA-RT-qPCR-ZY:
+    description: Concentration of genomic RNA of the N1 gene quantified using RT-qPCR
+      for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N2-gRNA-RT-qPCR-OG:
+    description: Concentration of genomic RNA of the N2 gene quantified using RT-qPCR
+      for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N2-gRNA-RT-qPCR-ZY:
+    description: Concentration of genomic RNA of the N2 gene quantified using RT-qPCR
+      for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N1-gRNA-ddPCR-OG:
+    description: Concentration of genomic RNA of the N1 gene quantified using ddPCR
+      for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N1-gRNA-ddPCR-ZY:
+    description: Concentration of genomic RNA of the N1 gene quantified using ddPCR
+      for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  E-gRNA-ddPCR-OG:
+    description: Concentration of genomic RNA of the E gene quantified using ddPCR
+      for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  E-gRNA-ddPCR-ZY:
+    description: Concentration of genomic RNA of the E gene quantified using ddPCR
+      for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N1-sgRNA-RT-qPCR-OG:
+    description: Concentration of sub-genomic RNA of the N1 gene quantified using
+      RT-qPCR for a sample collected using the OMNIGene GUT collection tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+  N1-sgRNA-RT-qPCR-ZY:
+    description: Concentration of sub-genomic RNA of the N1 gene quantified using
+      RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal collection
+      tube.
+    specimen: stool
+    limit_of_detection: 1000
+    limit_of_quantification: unknown
+participants:
+- attributes:
+    age: 55
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0161
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0162
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0163
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1039.755332
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 142
+    sample_id: COVRNA0514
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 142
+    sample_id: COVRNA0515
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2848.204101
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 181
+    sample_id: COVRNA0548
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 182
+    sample_id: COVRNA0564
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 182
+    sample_id: COVRNA0565
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0651
+- attributes:
+    age: 30
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 120.0
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0164
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0165
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0166
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 135
+    sample_id: COVRNA0468
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1056.3508
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2397.790456
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 135
+    sample_id: COVRNA0469
+- attributes:
+    age: 55
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0167
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0168
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0169
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4393.947614
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 350.0
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 147
+    sample_id: COVRNA0472
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 6805.079258
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 147
+    sample_id: COVRNA0473
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 813.0615276
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 253
+    sample_id: COVRNA0607
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 253
+    sample_id: COVRNA0608
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 294
+    sample_id: COVRNA0660
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 110.0
+    time: 294
+    sample_id: COVRNA0660
+- attributes:
+    age: 56
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0001
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0170
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 328.5700342
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0171
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 534.487385
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0172
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 180
+    sample_id: COVRNA0551
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2491.348183
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 80.0
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 180
+    sample_id: COVRNA0552
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 201
+    sample_id: COVRNA0577
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0578
+- attributes:
+    age: 21
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0173
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0174
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0175
+- attributes:
+    age: 62
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0002
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 140.0
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0176
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0177
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 544.8155203
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0178
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 286
+    sample_id: COVRNA0658
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 286
+    sample_id: COVRNA0658
+- attributes:
+    age: 37
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 310.60155979999996
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 168.48596569999998
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 344.224241
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0003
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 905.7844654
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 942.5662738
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 287.9036937
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 156.88479420000002
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0179
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 542.3203223
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 636.8234389
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0182
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1471.885303
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0510
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6753.9068640000005
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 80.0
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0513
+- attributes:
+    age: 58
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1062.598874
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1753.3278189999999
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2978.776458
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1472.0798049999999
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2377.04037
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1398.305845
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 340.0
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 340.0
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0004
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 278.10057379999995
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0183
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0184
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1890.9935600000001
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3357.384687
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 131
+    sample_id: COVRNA0474
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2476.75751
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 131
+    sample_id: COVRNA0475
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 282
+    sample_id: COVRNA0661
+- attributes:
+    age: 60
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: E-gRNA-ddPCR-OG
+    value: 210.0
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0185
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0186
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 245.4184407
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 962.1861791
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0439
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 263
+    sample_id: COVRNA0655
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 263
+    sample_id: COVRNA0655
+- attributes:
+    age: 25
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 607671.2698
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 128669.93289999999
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 658188.5678999999
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 139912.80299999999
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 948284.8537
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 516736.8071
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 902976.302
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 549101.5480999999
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1589170.0
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 8273000.0
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 8273000.0
+    time: 4
+    sample_id: COVRNA0005
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1401.859346
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 404.09918960000005
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 928.3288956
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 18807.52623
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4041.139031
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 23623.111380000002
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3920.7209719999996
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 13480.0
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: E-gRNA-ddPCR-OG
+    value: 500.0
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0188
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0188
+- attributes:
+    age: 29
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 400.8270496
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 814.8459846000001
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 528.8852512
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0006
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 10778.00552
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 3683.714723
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 8565.90259
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4185.724812
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 40665.28145
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 8271.206222
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 43499.19955
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 8585.126165
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 26800.0
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 2000.0
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 2000.0
+    time: 3
+    sample_id: COVRNA0189
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0190
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1642.2159510000001
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 141
+    sample_id: COVRNA0486
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2901.477617
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 141
+    sample_id: COVRNA0487
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 177
+    sample_id: COVRNA0571
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 177
+    sample_id: COVRNA0572
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 277
+    sample_id: COVRNA0659
+- attributes:
+    age: 37
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 26552.03019
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6668.167312
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 22841.3927
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 8388.031248000001
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 16987.63005
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 11590.86477
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 21062.19237
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 15082.53101
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 4210.0
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 3480.0
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0007
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1280.8777790000001
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1348.237697
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 270.0
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0191
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 307.9926544
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0192
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0193
+- attributes:
+    age: 22
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1191.467294
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 840.6345049
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1329.535011
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1745.0259939999999
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0194
+- attributes:
+    age: 25
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 14279.937950000001
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5616.642384000001
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 17892.48476
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 6324.539495999999
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 66788.63724
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 27548.25133
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 54142.58353
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 31112.84634
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: E-gRNA-ddPCR-OG
+    value: 120.0
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 41230.0
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 5000.0
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 10000.0
+    time: 5
+    sample_id: COVRNA0195
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2879.050342
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1460.267668
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 729.9791678
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 270.0
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0196
+- attributes:
+    age: 50
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0008
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 873.3201618999999
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0197
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 579.320263
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 646.6772940999999
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 363.1297423
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 578.0438991999999
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 223.4629482
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 360.0
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0198
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0649
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0673
+- attributes:
+    age: 60
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 216.2060484
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0009
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 184.2324045
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 516.6726595
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0010
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0199
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 569.3742656000001
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 420.5998561
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0200
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0201
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 150
+    sample_id: COVRNA0519
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1462.052851
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 150
+    sample_id: COVRNA0520
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 205
+    sample_id: COVRNA0595
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 210.0
+    time: 205
+    sample_id: COVRNA0596
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0666
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 170.0
+    time: 280
+    sample_id: COVRNA0666
+- attributes:
+    age: 42
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 322.1946563
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0202
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0203
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 80.0
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: E-gRNA-ddPCR-OG
+    value: 80.0
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0204
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0586
+- attributes:
+    age: 63
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0011
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0012
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0205
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0206
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 435.0890796
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0207
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3002.529281
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1492.663678
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 124
+    sample_id: COVRNA0476
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2246.038634
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1324.397015
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 80.0
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 124
+    sample_id: COVRNA0477
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 197
+    sample_id: COVRNA0588
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0589
+- attributes:
+    age: 22
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1972.4089060000001
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2795.116961
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1446.166245
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3637.535962
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2287.072452
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2733.367905
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3139.072122
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 520.0
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 520.0
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0013
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1855.869614
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 938.128149
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1002.9511440000001
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 825.0501247999999
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 61014045000.0
+    time: 5
+    sample_id: COVRNA0208
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 394.60895159999995
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 390.72566320000004
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1099.804147
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 289.8532191
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 918.3669241
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 261.8891687
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 420.0
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: E-gRNA-ddPCR-OG
+    value: 320.0
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0209
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 489.2202083
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 239.0441317
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0210
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0581
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0582
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0671
+- attributes:
+    age: 28
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 415.8498935
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 7009.010497
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3706.713605
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6518.551236
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4841.259854
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 2400.0
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: E-gRNA-ddPCR-OG
+    value: 310.0
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0211
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0212
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 7164.466523
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 113
+    sample_id: COVRNA0511
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1598.468447
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0512
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0592
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0672
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 279
+    sample_id: COVRNA0672
+- attributes:
+    age: 39
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0214
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 813.9196059
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 362.89006470000004
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 230.0
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0215
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 176.4599446
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0216
+- attributes:
+    age: 33
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 854.2681725
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 2000.0
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 2950.0
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0014
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 11172.86124
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1859.354985
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 10367.92763
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1138.037066
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 13414.33867
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 7377.269739
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 12417.70846
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6923.802352
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 3950.0
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 4050.0
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7000.0
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 15000.0
+    time: 29
+    sample_id: COVRNA0015
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 10104.85744
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2970.476389
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1815.3051899999998
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 34534.103780000005
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 14627.246219999999
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 17807.1105
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 22590.0
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: E-gRNA-ddPCR-OG
+    value: 5370.0
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 7000.0
+    time: 3
+    sample_id: COVRNA0217
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 9880.24957
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5264.127004
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5492.858458
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 2190.0
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0218
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1496.217267
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2057.301379
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1087.717932
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 15050.2505
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5560.163605
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 11956.81272
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4275.315056
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 5270.0
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0219
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0219
+- attributes:
+    age: 31
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 376.8623017
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0220
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0221
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0222
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1709.2028990000001
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2990.810803
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 1360.0
+    time: 210
+    sample_id: COVRNA0597
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0598
+- attributes:
+    age: 29
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 385.818183
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 589.4537424
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 5111.999683
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3843.566048
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4422.308282
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3898.113843
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 640.0
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0223
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6775.903829
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1960.953171
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4931.669844
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1614.157064
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 168561.9665
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 62778.05169
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 173380.82739999998
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 51586.740399999995
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: E-gRNA-ddPCR-OG
+    value: 3410.0
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 140110.0
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 4000.0
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0224
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0225
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 200.0
+    time: 210
+    sample_id: COVRNA0599
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0600
+- attributes:
+    age: 20
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 6202.153071
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 5883.247227
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 6625.927474
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 4971.446142999999
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 22786.2946
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 9775.451851
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 20495.14693
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 10241.59585
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 13250.0
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0016
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 14797.45341
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 4088.7958810000005
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 14431.268559999999
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3978.1223579999996
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 16794.80071
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 11677.33978
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 15673.94934
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 10449.80547
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 6350.0
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 22000.0
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 10000.0
+    time: 14
+    sample_id: COVRNA0017
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 230.0
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0018
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1284.079056
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1056.699973
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1971.789749
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1347.068648
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 400.0
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0226
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 867.9700775
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0227
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 425.0237128
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4874.635581
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1684.505572
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4195.588292
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2307.220854
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: E-gRNA-ddPCR-OG
+    value: 100.0
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 920.0
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0228
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 254.15566769999998
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0229
+- attributes:
+    age: 30
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0019
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0020
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0230
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0231
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 289.4180485
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0232
+- attributes:
+    age: 60
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 210.0
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0021
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0233
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 204.5861424
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0234
+- attributes:
+    age: 26
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 5402.581004
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2335.121621
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 7074.304697
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1297.7578649999998
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7507.733467
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3766.983408
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7299.157496000001
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5402.793452
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 890.0
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1570.0
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 4000.0
+    time: 14
+    sample_id: COVRNA0022
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 4633.866658
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2190.107043
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3717.886381
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2598.696094
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4491.207094
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4884.91398
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4046.231336
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5868.4657290000005
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1220.0
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 850.0
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 29
+    sample_id: COVRNA0023
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4679.019709
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2062.145155
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2943.344095
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1388.123213
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0235
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 390.2779054
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 418.3959425
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0236
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2234.7248830000003
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 464.1880187
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1239.527899
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 315.1135077
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 29
+    sample_id: COVRNA0237
+- attributes:
+    age: 27
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 8623.993091999999
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3996.65097
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 5655.62621
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2496.8199910000003
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 9343.563309000001
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 7337.768172
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 6312.985665
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6404.609883
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1180.0
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1500.0
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7000.0
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0024
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 662.8394495
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 609.3306756
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 420.4199024
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 220.0
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0238
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 36244.07786
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 33226.97514
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 28577.57559
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 32102.720810000003
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 219989.9139
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 37390.49562
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 102974.31520000001
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 34946.385200000004
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: E-gRNA-ddPCR-OG
+    value: 14640.0
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 98310.0
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 14000.0
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 27000.0
+    time: 11
+    sample_id: COVRNA0239
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 450.0
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0240
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1581.3355099999999
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 123
+    sample_id: COVRNA0494
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1069.6174819999999
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 123
+    sample_id: COVRNA0495
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 195
+    sample_id: COVRNA0590
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0591
+- attributes:
+    age: 26
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 94316.71040000001
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 20632.79438
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 100629.6979
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 23386.897869999997
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 162488.307
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 85671.71195
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 160187.95679999999
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 97190.04417
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 127880.0
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 425000.0
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 425000.0
+    time: 13
+    sample_id: COVRNA0025
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 80216.37443
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 15387.97311
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 90486.30633
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 14427.91721
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 82631.56603
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 81266.09188
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 91027.13657
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 74621.3937
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 67210.0
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 61800.0
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 28
+    sample_id: COVRNA0026
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 16060.158990000002
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 30761.75163
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 17299.50676
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 22150.31735
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 96525.13387
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 31470.48322
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 99456.20513
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 35256.85844
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: E-gRNA-ddPCR-OG
+    value: 7220.0
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 54770.0
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 4000.0
+    time: 2
+    sample_id: COVRNA0241
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 25741.23489
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 3931.1498450000004
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 23323.7752
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 3439.775453
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 56677.12285000001
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 17607.55331
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 53620.260500000004
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 23851.65294
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 44050.0
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 10000.0
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 22000.0
+    time: 13
+    sample_id: COVRNA0242
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 626.2784958999999
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1378.69758
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 9975.423442000001
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1495.341697
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10204.40943
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1116.253444
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 4210.0
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: E-gRNA-ddPCR-OG
+    value: 340.0
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0243
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1642.359316
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 80.0
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 138
+    sample_id: COVRNA0502
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 138
+    sample_id: COVRNA0503
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 200
+    sample_id: COVRNA0593
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0594
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 190.0
+    time: 200
+    sample_id: COVRNA0594
+- attributes:
+    age: 28
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1235.2938849999998
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1046.2713239999998
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3158.676417
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1860.772673
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2904.3100680000002
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2031.036094
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0244
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0244
+- attributes:
+    age: 34
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 109521.3507
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 19971.65808
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 111660.3171
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 20480.250659999998
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 112043.7685
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 93010.89133000001
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 100526.3452
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 92534.51518999999
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 116860.0
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 132160.0
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 102000.0
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 102000.0
+    time: 10
+    sample_id: COVRNA0027
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 957.3394024
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 573.5684546000001
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1147.263868
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 600.0869599
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1163.890549
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 576.3106662
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 130.0
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 130.0
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0028
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0245
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 41683.39055
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 7885.321866
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 9624.625662
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 62448.03529
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 31509.34806
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 36173.49876
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 30080.0
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 22000.0
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0246
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 882.1980457000001
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 812.7812561
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 864.3965083
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0247
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2330.981391
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0470
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0471
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 235
+    sample_id: COVRNA0636
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0679
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 298
+    sample_id: COVRNA0679
+- attributes:
+    age: 43
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 5652.655781
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1327.26286
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 4793.620847
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1099.0398779999998
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 28158.70646
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 10622.31343
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 28032.25906
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 11048.305450000002
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 3880.0
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 24940.0
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0029
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 31496.18139
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3715.036473
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 30590.44481
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3381.151312
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 33915.04051
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 21757.37749
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 30539.753350000003
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 19487.35074
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 17240.0
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 20740.0
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 15000.0
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7000.0
+    time: 27
+    sample_id: COVRNA0030
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2439.0454099999997
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 637.6824732
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2622.729046
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1708.317409
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 160.0
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0248
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 27122.28004
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4763.093036
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 28163.49224
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4759.207047
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 157826.07960000003
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 17787.7395
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 172169.1371
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 24501.21972
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: E-gRNA-ddPCR-OG
+    value: 58350.0
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 624220.0
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 7000.0
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 7000.0
+    time: 10
+    sample_id: COVRNA0249
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 282.3709586
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 395.2324251
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 220.0
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0250
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4170.2020299999995
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3787.218791
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 500.0
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0544
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1454.5039689999999
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 19190.951399999998
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 21028.88484
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 6920.0
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 17000.0
+    time: 151
+    sample_id: COVRNA0545
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0616
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 220.0
+    time: 227
+    sample_id: COVRNA0617
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 291
+    sample_id: COVRNA0681
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 160.0
+    time: 291
+    sample_id: COVRNA0681
+- attributes:
+    age: 35
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 18087.02455
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 10390.73142
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 20626.93952
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 7538.257600999999
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 32494.796630000004
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 22193.57544
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 32295.713390000004
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 20691.18987
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 14170.0
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 10040.0
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 27000.0
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 27000.0
+    time: 10
+    sample_id: COVRNA0031
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 656.4985945000001
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1030.3634909999998
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 585.2057802
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0032
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 52661.96769
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 21030.64169
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 50580.42786
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 19162.26901
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 89164.31337999999
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 68949.5769
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 90954.18203
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 57047.20167
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 42390.0
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 202000.0
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 202000.0
+    time: 2
+    sample_id: COVRNA0251
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4131.85293
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 3594.378658
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 26597.43341
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5537.574321
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 26031.90145
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 6812.711023000001
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1280.0
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 10420.0
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0252
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 290.0
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0253
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4323.746221
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 35907.63058999999
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3587.153916
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 151
+    sample_id: COVRNA0542
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3467.4875460000003
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2683.8398890000003
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 151
+    sample_id: COVRNA0543
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 227
+    sample_id: COVRNA0613
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 110.0
+    time: 227
+    sample_id: COVRNA0614
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0677
+- attributes:
+    age: 62
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0033
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0034
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0035
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0254
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0255
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 603.3266061
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0256
+- attributes:
+    age: 59
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 154870.6496
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 42641.10491
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 147589.5944
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 47431.77104
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 181157.99190000002
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 119858.21919999999
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 163399.795
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 130485.80380000001
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 71520.0
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 83300.0
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 119000.0
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 4
+    sample_id: COVRNA0036
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 896.0911043000001
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1510.79188
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0037
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1642.958805
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1317.9286
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2748.802726
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 857.3085157
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3003.162725
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1036.7652620000001
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 390.0
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 13
+    sample_id: COVRNA0049
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 405.8074818
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3113.30494
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 595.2574992
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2507.159691
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 447.70381199999997
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 1960.0
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: E-gRNA-ddPCR-OG
+    value: 120.0
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0257
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0258
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1634.2441430000001
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1244.76481
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 461.69098590000004
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0274
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1697.103042
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 130
+    sample_id: COVRNA0483
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1713.289676
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1168.238514
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 130
+    sample_id: COVRNA0484
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 228
+    sample_id: COVRNA0629
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 298
+    sample_id: COVRNA0686
+- attributes:
+    age: 33
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 329.862864
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 315.24860259999997
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1094.601144
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 682.7314574999999
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 337.7975409
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 190.0
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 90.0
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0038
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 175.44487619999998
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0039
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 637.4551968
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 742.0676436
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 757.0002349
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1284.144172
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 120.0
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0259
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 303.5010592
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 177.6211171
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0260
+- attributes:
+    age: 32
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 66688.25332
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 30180.07073
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 80191.70029
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 28613.081879999998
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 81862.90531999999
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 49290.73409
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 85216.30374999999
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 54406.6827
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 39100.0
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: 2
+    sample_id: COVRNA0040
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 125708.7502
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 50081.93428
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 140427.5878
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 40907.61135000001
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 133945.4615
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 32400.73986
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 140207.6681
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 37090.80941
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 135550.0
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 135900.0
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 119000.0
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 119000.0
+    time: 13
+    sample_id: COVRNA0041
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 632.6035423000001
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3906.746464
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2501.8238
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3606.358717
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2149.582956
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 950.0
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0261
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 698.7532848
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 5654.2691239999995
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1386.868848
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2972.5835859999997
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2088.977862
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 1630.0
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0262
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 641.388801
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 223
+    sample_id: COVRNA0622
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 223
+    sample_id: COVRNA0622
+- attributes:
+    age: 44
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0263
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0264
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 562.9753724
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0265
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 201
+    sample_id: COVRNA0601
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 230.0
+    time: 201
+    sample_id: COVRNA0601
+- attributes:
+    age: 21
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0042
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0043
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0044
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 476.7313802
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 623.3000499
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0266
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1801.5573279999999
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2827.050149
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 5683.841715
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4045.7995960000003
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6604.635975
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4027.146061
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 1380.0
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0267
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0268
+- attributes:
+    age: 24
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 8160.072862
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2415.048174
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 6896.162252
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1949.593812
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 9029.169016999998
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6519.734448
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 8310.671061000001
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5611.347457
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 3450.0
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 2210.0
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 4000.0
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0045
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 110.0
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0046
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 755.2263922
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1394.4942629999998
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1460.459215
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2687.63805
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6669.807382
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 6242.440247
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4616.828558
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4199.636387
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: E-gRNA-ddPCR-OG
+    value: 290.0
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 680.0
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0269
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5847.833995
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 3562.1793629999997
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5683.220053
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2861.782829
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 19505.95872
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 6088.056381
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 18608.31338
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4877.425658
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: E-gRNA-ddPCR-OG
+    value: 2220.0
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 9830.0
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0270
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 450.2926984
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 553.6000907
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0271
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1416.107781
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 100
+    sample_id: COVRNA0466
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1041.594855
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 100
+    sample_id: COVRNA0467
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 290.0
+    time: 196
+    sample_id: COVRNA0602
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0678
+- attributes:
+    age: 63
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 962.8159603
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1403.045776
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 839.7905503000001
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 939.0634952
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 5
+    sample_id: COVRNA0047
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 206.2637627
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 15
+    sample_id: COVRNA0048
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0272
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0273
+- attributes:
+    age: 62
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1605.909848
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2151.422305
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2940.8973619999997
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3113.663012
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 5726.333331
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6100.36581
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 8627.900092000002
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6108.040194
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 810.0
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1620.0
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 0
+    sample_id: COVRNA0050
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 46905.07415
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 11167.97644
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 45862.30195
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 12007.54813
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 51600.58161
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 22464.95855
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 49985.8961
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 20384.34852
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 50850.0
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 40220.0
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 119000.0
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 60000.0
+    time: 10
+    sample_id: COVRNA0051
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 788.9132880000001
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1092.033867
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1125.976907
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1226.5285130000002
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0052
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 71422.73942
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 36676.78108
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 68722.95184
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 33607.07965
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 159661.35510000002
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 58241.90204
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 203014.10859999998
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 68452.45903
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 317570.0
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 202000.0
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 202000.0
+    time: 0
+    sample_id: COVRNA0275
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 25849.257869999998
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 7978.581649
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 26540.23355
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 7189.841635
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 34827.6495
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 30261.42006
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 40432.027689999995
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 27549.82468
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 21120.0
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 5000.0
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 22000.0
+    time: 10
+    sample_id: COVRNA0276
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 32221.21378
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 13381.49749
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 30885.69243
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 10242.38697
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 52211.19747
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 28673.140339999998
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 50687.30387
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 37762.74639
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 21740.0
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 22000.0
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 46000.0
+    time: 28
+    sample_id: COVRNA0277
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0490
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1839.679304
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0493
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 715.6767427000001
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 214
+    sample_id: COVRNA0627
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1979.363874
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2354.9922140000003
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1390.0
+    time: 214
+    sample_id: COVRNA0628
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 281
+    sample_id: COVRNA0676
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 281
+    sample_id: COVRNA0676
+- attributes:
+    age: 30
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 378023.50669999997
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 43480.04539
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 342799.11750000005
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 43914.92922
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 506912.21009999997
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 283287.37189999997
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 523889.9481
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 267185.024
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 449430.0
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 836120.0
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1469000.0
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1469000.0
+    time: 0
+    sample_id: COVRNA0053
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 680.7335752
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 16448.65827
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6239.796094
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 16783.46236
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 7080.440694
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 190.0
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 3560.0
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0054
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 110.0
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0055
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2241.012693
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1392.69883
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 720.4428185
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1537.9485129999998
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0279
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 508.92493390000004
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0280
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 190.0
+    time: 220
+    sample_id: COVRNA0642
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 288
+    sample_id: COVRNA0683
+- attributes:
+    age: 45
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 365161.5566
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 92034.09252
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 427694.16260000004
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 83518.76208
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 375119.507
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 347205.16579999996
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 385488.20769999997
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 334371.9246
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 363600.0
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 427020.0
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 755000.0
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 6
+    sample_id: COVRNA0056
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 385095.04020000005
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 98678.66641
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 423267.1896
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 86757.92817
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 411938.7345
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 168717.42309999999
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 382717.4155
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 175259.3046
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 475890.0
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 371880.0
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 9
+    sample_id: COVRNA0057
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 281.2081207
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 30
+    sample_id: COVRNA0058
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4998.533307
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1519.441673
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3170.204612
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1477.024619
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 840.0
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 6
+    sample_id: COVRNA0281
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: E-gRNA-ddPCR-OG
+    value: 110.0
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 30
+    sample_id: COVRNA0282
+- attributes:
+    age: 42
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 57787.15999
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 13282.35237
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 68011.03469
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 12203.87523
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 72984.69690000001
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 39528.53999
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 74487.41004
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 39948.62173
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 47070.0
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 53370.0
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 30000.0
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 15000.0
+    time: unknown
+    sample_id: COVRNA0059
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 558.5025759
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 339.640827
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1134.891695
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 372.6507602
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 735.8585718
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 705.653656
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 190.0
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 290.0
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0060
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 218055.6932
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 68169.74485
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 248243.0644
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 65038.489100000006
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 261836.5511
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 220777.97530000002
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 257352.44569999998
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 192489.8381
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 188870.0
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 893000.0
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 425000.0
+    time: unknown
+    sample_id: COVRNA0061
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 185811.61000000002
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 36216.05459
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 181553.0162
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 36849.14481
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 294676.4908
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 248848.67779999998
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 381689.7061
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 219002.3923
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: E-gRNA-ddPCR-OG
+    value: 167230.0
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 347850.0
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 1469000.0
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 1469000.0
+    time: unknown
+    sample_id: COVRNA0283
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 992.2919039
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1169.873104
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1196.274524
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2531.428112
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: E-gRNA-ddPCR-OG
+    value: 680.0
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 800.0
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0284
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 3274.346092
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2420.759309
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 20809.753090000002
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 8830.444307
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 19587.89096
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 6931.27486
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 30970.0
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: E-gRNA-ddPCR-OG
+    value: 3070.0
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0285
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 250.0
+    time: 211
+    sample_id: COVRNA0611
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 689.2542238
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 641.2115484999999
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 480.0
+    time: 211
+    sample_id: COVRNA0612
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 140.0
+    time: 212
+    sample_id: COVRNA0637
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 244
+    sample_id: COVRNA0650
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 244
+    sample_id: COVRNA0650
+- attributes:
+    age: 57
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 175.7917126
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0062
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 665.0996615
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 160.0
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0063
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 427.1591259
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 867.0798548
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0287
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 626.6132543
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 211
+    sample_id: COVRNA0618
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 211
+    sample_id: COVRNA0619
+- attributes:
+    age: 63
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0064
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1483.386346
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1900.853181
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2311.59004
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1704.018174
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4103.358884
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1879.016548
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 840.0
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 560.0
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0065
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0066
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 179.5962723
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0288
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6927.840448000001
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4121.631081
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5975.594463
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4778.198214999999
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 62128.571970000005
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 24717.34789
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 77755.89719
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 21946.272839999998
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 63100.0
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 2000.0
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0289
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 897.4974418
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 130.0
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0290
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1037.472615
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0478
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0479
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 486.3313556
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 260.0
+    time: 189
+    sample_id: COVRNA0603
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 189
+    sample_id: COVRNA0604
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 278
+    sample_id: COVRNA0674
+- attributes:
+    age: 21
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0291
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 172
+    sample_id: COVRNA0587
+- attributes:
+    age: 64
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 15692.978070000001
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1255.192845
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 13259.4257
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1071.49804
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 13474.385610000001
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 12315.044049999999
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 13858.740530000001
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 14662.45288
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 5560.0
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 5280.0
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 14000.0
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 4000.0
+    time: 14
+    sample_id: COVRNA0067
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0068
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 488.0672727
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1496.864247
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3075.493847
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1412.5833619999999
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3090.647022
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 724.4454331
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 2760.0
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 920.0
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0069
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1240.630543
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1328.542952
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4330.835199
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1869.886597
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3707.321468
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1042.7197560000002
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 2460.0
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: E-gRNA-ddPCR-OG
+    value: 870.0
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0292
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0293
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1197.026701
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 323.2493419
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 770.0080125
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 545.4365951
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 220.0
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: E-gRNA-ddPCR-OG
+    value: 220.0
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0294
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2862.030289
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0480
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1076.86197
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0481
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 210
+    sample_id: COVRNA0625
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 430.7441649
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0626
+- attributes:
+    age: 45
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0070
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0071
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0072
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 531.8363860000001
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 743.2991193
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0295
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: E-gRNA-ddPCR-OG
+    value: 110.0
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0296
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0297
+- attributes:
+    age: 21
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3593901.03
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1437759.165
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3809958.301
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1433537.732
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7240399.379000001
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4953446.619
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 6174466.056
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4220449.209000001
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 6497010.0
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 8728920.0
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 21066000.0
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 21066000.0
+    time: 4
+    sample_id: COVRNA0073
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1679225.9810000001
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 389707.512
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1715899.499
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 368580.8209
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2088673.5920000002
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1316087.501
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1996176.919
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1292481.0999999999
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 4854880.0
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 5624210.0
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 5564000.0
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 5564000.0
+    time: unknown
+    sample_id: COVRNA0074
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 625111.8825999999
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 159190.41770000002
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 555227.2683
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 127738.9374
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 785468.6359
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 692289.6179000001
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 788442.85
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 602677.0883000001
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 826580.0
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1035930.0000000001
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1912000.0
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1912000.0
+    time: unknown
+    sample_id: COVRNA0075
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 246896.9241
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 65781.25997
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 223024.2623
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 62648.27529
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1033465.136
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 531242.2124
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1015236.562
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 440218.2228
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: E-gRNA-ddPCR-OG
+    value: 189490.0
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 1503410.0
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 388000.0
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 388000.0
+    time: 4
+    sample_id: COVRNA0298
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1799.6781529999998
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 384.3381361
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1663.064137
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 598.0036362999999
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 17108.96485
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 7537.614366
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 16242.136089999998
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 8862.290005
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: E-gRNA-ddPCR-OG
+    value: 3640.0
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 34090.0
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0299
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 7228.702879
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1522.405601
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 10545.133749999999
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2439.9403089999996
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 131023.033
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 33058.99977
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 135108.7224
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 37444.54875
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: E-gRNA-ddPCR-OG
+    value: 5140.0
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 103080.0
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 7000.0
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 14000.0
+    time: unknown
+    sample_id: COVRNA0300
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0665
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0675
+- attributes:
+    age: 21
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 137313.5288
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 21318.17847
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 133672.8455
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 22870.17261
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 195389.9675
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 137639.2124
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 198170.1952
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 129270.6862
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 128320.0
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 158410.0
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 478000.0
+    time: 1
+    sample_id: COVRNA0076
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 166090.5339
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 28923.88197
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 150534.40459999998
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 27452.83917
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 139187.8939
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 91219.80041000001
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 146349.8058
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 84848.70416
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 128710.00000000001
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 105480.0
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 102000.0
+    time: 15
+    sample_id: COVRNA0077
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1944.797421
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 445.0733642
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1906.880422
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 405.5102653
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 4660.0
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: E-gRNA-ddPCR-OG
+    value: 130.0
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0301
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 754.6436851
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1923.769917
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 45360.58501
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 10830.0898
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 53229.41067
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 10174.66082
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 37650.0
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0302
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0302
+- attributes:
+    age: 26
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3183.904461
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3499.996989
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3406.434237
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2270.6359150000003
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 5270.413533
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3029.3634859999997
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 760.0
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 940.0
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0078
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1670.7362560000001
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1268.8715530000002
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 747.4175519
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10563.81661
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2833.026906
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 9454.140556
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3136.707192
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1400.0
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 8920.0
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 8
+    sample_id: COVRNA0079
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1540.7783299999999
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1157.884347
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1232.835736
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1119.232309
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 504.9566123
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 250.0
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0080
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 734.592484
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1114.505032
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2609.350097
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 676.166966
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3377.476897
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 360.0
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0303
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1543.260927
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 698.6217894
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1255.501276
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 492.2957966
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 10166.48397
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1502.232336
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 9813.442624000001
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2617.882518
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1490.0
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 10480.0
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 8
+    sample_id: COVRNA0304
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 490.17690739999995
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 368.5793006
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 829.3771747999999
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 601.0650825
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: E-gRNA-ddPCR-OG
+    value: 540.0
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0305
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1246.024831
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 110.0
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0491
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1072.3334929999999
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2149.815131
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 107
+    sample_id: COVRNA0492
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 213
+    sample_id: COVRNA0646
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 279
+    sample_id: COVRNA0685
+- attributes:
+    age: 40
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0081
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 9
+    sample_id: COVRNA0082
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 287.3201441
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0083
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 26
+    sample_id: COVRNA0084
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 259.7774463
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0306
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 9
+    sample_id: COVRNA0307
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 20
+    sample_id: COVRNA0308
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 26
+    sample_id: COVRNA0309
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 280
+    sample_id: COVRNA0684
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 280
+    sample_id: COVRNA0684
+- attributes:
+    age: 36
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 302889.9806
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 23152.82966
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 534151.1032
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 15366.79398
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1476016.2889999999
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 742114.2598
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1708541.5680000002
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 730418.1536999999
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 212540.0
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 984030.0
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 3824000.0
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 3824000.0
+    time: 1
+    sample_id: COVRNA0085
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 197993.0881
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 44126.87638
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 193566.1736
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 38714.14084
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 183561.8696
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 107454.3054
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 197027.19400000002
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 116794.3391
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 182350.0
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 202000.0
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 202000.0
+    time: 17
+    sample_id: COVRNA0086
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 920.7681621
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 41
+    sample_id: COVRNA0420
+- attributes:
+    age: 52
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 34932.23424
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 8662.97569
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 36871.1118
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 10995.34056
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 57999.56932
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 27928.77724
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 57532.45646
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 27963.816489999997
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 25130.0
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 10000.0
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 22000.0
+    time: 1
+    sample_id: COVRNA0087
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 43401.584389999996
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 18217.08899
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 44876.150590000005
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 16117.99178
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 63248.48893
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 45649.050090000004
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 70056.80902999999
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 45125.84192
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 27410.0
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 33630.0
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 9
+    sample_id: COVRNA0088
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0089
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10394.48739
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2531.16063
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10851.19735
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3951.970616
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 3980.0
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0310
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0311
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3250.45798
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1770.3626020000002
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0496
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1776.444077
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0497
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1883.862934
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1498.748626
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2553.990803
+    time: 222
+    sample_id: COVRNA0668
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1100.0
+    time: 222
+    sample_id: COVRNA0668
+- attributes:
+    age: 37
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1230.655358
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1723.26077
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1260.066049
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1210.074982
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1367.655713
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 713.6669912
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1220.0
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 660.0
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0090
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0312
+- attributes:
+    age: 51
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 10562.42614
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 5048.31274
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 9373.480809
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 5074.831816
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 19230.97402
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 7189.475712
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 19679.25373
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 7640.412923999999
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 5200.0
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 2820.0
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 30000.0
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 30000.0
+    time: 3
+    sample_id: COVRNA0091
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 10
+    sample_id: COVRNA0092
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 25
+    sample_id: COVRNA0093
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6419.900055
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5106.97695
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5581.410258
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5469.697932
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 18932.95604
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 9438.175967
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 17901.616570000002
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 8488.763544
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 7680.0
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1470.0
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 7000.0
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0313
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 290.0
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0314
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0315
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3306.876399
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3801.97694
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 180.0
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0488
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1714.272424
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0489
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 202
+    sample_id: COVRNA0609
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 421.3669415
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 202
+    sample_id: COVRNA0610
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 273
+    sample_id: COVRNA0680
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 120.0
+    time: 273
+    sample_id: COVRNA0680
+- attributes:
+    age: 39
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1826418.1860000002
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 257953.60620000004
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1769588.1509999998
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 227824.3452
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1803668.4379999998
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1560781.254
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1762393.396
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1560512.938
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 4179250.0
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 4808350.0
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7649000.0
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7649000.0
+    time: 0
+    sample_id: COVRNA0094
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 20771.82131
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 16579.77829
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 20618.536379999998
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 15410.240670000001
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 168829.7939
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 69055.3746
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 143467.7068
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 72996.18699
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 134390.0
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: E-gRNA-ddPCR-OG
+    value: 7100.0
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 27000.0
+    time: 0
+    sample_id: COVRNA0316
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 14000.0
+    time: 0
+    sample_id: COVRNA0316
+- attributes:
+    age: 42
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 361.19823829999996
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 1
+    sample_id: COVRNA0095
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0096
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0097
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0317
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 262.6024199
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0318
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 223.00111049999998
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 191.9486365
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0319
+- attributes:
+    age: 37
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 67175.28457
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 20684.43636
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 73949.81597
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 18382.51935
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 101302.16609999999
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 73379.12899
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 95463.81261000001
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 55438.69485
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 35620.0
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: 1
+    sample_id: COVRNA0098
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 13753.18887
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6063.0991730000005
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 15491.47623
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3876.63387
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 14150.509109999999
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 8211.057338999999
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 16071.37973
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 8892.636331
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 6120.0
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 2000.0
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 10000.0
+    time: 15
+    sample_id: COVRNA0099
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 3503.384534
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1525.647271
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 3884.991347
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1408.7170099999998
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 20844.07357
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 14427.04252
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 21188.78952
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 10239.53888
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1010.0
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 6780.0
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0320
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1014.458938
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1997.05307
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6875.749454
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2739.306992
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6664.264817
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3459.886879
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 4250.0
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0321
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0321
+- attributes:
+    age: 28
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 28567.234030000003
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 12577.93376
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 34328.360779999995
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 15649.49296
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 27352.97954
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 34907.91687
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 30645.10648
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 28619.910789999998
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 12180.0
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 12090.0
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 14000.0
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7000.0
+    time: 1
+    sample_id: COVRNA0100
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2539.117932
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2126.944338
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1258.8113489999998
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3017.3318990000002
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2553.053308
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3382.280614
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3625.9563780000003
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 570.0
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 950.0
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 12
+    sample_id: COVRNA0101
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1389.0464069999998
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2325.050753
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 16026.151980000002
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 12799.531860000001
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 18250.67612
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 9036.816615
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 6890.0
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: E-gRNA-ddPCR-OG
+    value: 310.0
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0322
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 12
+    sample_id: COVRNA0323
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 303.3048002
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0399
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 295.5589679
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0400
+- attributes:
+    age: 27
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 95406.66439
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 7190.8645240000005
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 102905.3284
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6662.9815
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 85982.5355
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 76816.33023
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 86678.78001
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 84232.26579
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 82670.0
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 84340.0
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 0
+    sample_id: COVRNA0102
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0103
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 263.7421481
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0382
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1421.7989630000002
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1466.636552
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 99
+    sample_id: COVRNA0485
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0647
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 204
+    sample_id: COVRNA0647
+- attributes:
+    age: 38
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 15131.02095
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 5848.732027
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 11379.93723
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6050.7376620000005
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 18986.556379999998
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 13788.40396
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 17015.31349
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 15169.3446
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 6220.0
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 4910.0
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 53000.0
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 14000.0
+    time: 3
+    sample_id: COVRNA0104
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 90899.39879
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 27768.8528
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 84662.01193000001
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 26119.712580000003
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 131445.9418
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 57167.99488
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 135270.25209999998
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 56400.3993
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 75580.0
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: 14
+    sample_id: COVRNA0105
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 7184.492746
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 7035.8891220000005
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 595.36903
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 3440.0
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0324
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 603.4952552
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1193.8453710000001
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 926.5468567
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10246.86083
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1286.263978
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 8959.049512
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1479.113269
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: E-gRNA-ddPCR-OG
+    value: 420.0
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 2830.0
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0325
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 109
+    sample_id: COVRNA0506
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3180.4446820000003
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 839.9527264
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2672.864399
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 109
+    sample_id: COVRNA0507
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1560.113508
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 80.0
+    time: 196
+    sample_id: COVRNA0623
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 496.6990994
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0624
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 310.0
+    time: 196
+    sample_id: COVRNA0624
+- attributes:
+    age: 30
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0106
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0326
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0327
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 361.415158
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0383
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 5855485.448000001
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 499.1381601
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 110.0
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0384
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 104
+    sample_id: COVRNA0500
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1969.76606
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0501
+- attributes:
+    age: 32
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1297.347375
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 14
+    sample_id: COVRNA0107
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0328
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0413
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0414
+- attributes:
+    age: 34
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 435505.33009999996
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 22734.601990000003
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 440286.0842
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 22515.67402
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 554426.5582000001
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 326373.5729
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 670892.0227999999
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 342059.8869
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1116710.0
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1406210.0
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1469000.0
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1469000.0
+    time: 14
+    sample_id: COVRNA0108
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2794.129394
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1057.978047
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2591.3933180000004
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1413.3265239999998
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 14649.034179999999
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2898.56956
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 14732.979200000002
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2469.040315
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 6510.0
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0329
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 811.4671445
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 983.6979718
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 450.55375399999997
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1933.806873
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 170.0
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0330
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 12186.0877
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 11920.59789
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 923.5552309
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 594.1870824
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 23
+    sample_id: COVRNA0385
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 23
+    sample_id: COVRNA0386
+- attributes:
+    age: 43
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0109
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3913.74485
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1420.507869
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3921.947806
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1280.553111
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7564.562029000001
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3654.974565
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7085.528733
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3296.368278
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 2020.0
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0110
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 660.3862051
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 775.162954
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 660.0117513
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 120.0
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 4
+    sample_id: COVRNA0111
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 407.8315243
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0331
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 4
+    sample_id: COVRNA0332
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2128.7291480000004
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3482.133992
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0523
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0524
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 241
+    sample_id: COVRNA0670
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 271
+    sample_id: COVRNA0682
+- attributes:
+    age: 21
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 181409.77860000002
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 66071.34912
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 203192.3341
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 72551.75991000001
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 206148.5474
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 175475.0417
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 215251.9993
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 180953.2209
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 153730.0
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 125520.0
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 3
+    sample_id: COVRNA0112
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 84079.91974
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 21443.41298
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 98198.18714
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 19787.81883
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 72622.44049000001
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 85933.24925000001
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 75860.0461
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 94703.19275999999
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 61660.0
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 67320.0
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 102000.0
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 53000.0
+    time: 11
+    sample_id: COVRNA0113
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 177.3353774
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 182.14795249999997
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 11
+    sample_id: COVRNA0333
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1595.791714
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0405
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0406
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 200
+    sample_id: COVRNA0634
+- attributes:
+    age: 28
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1928.2085470000002
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 749.4452013
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2152.769072
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1228.837296
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3297.601167
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1879.0383100000001
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 500.0
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 420.0
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0114
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0114
+- attributes:
+    age: 20
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 110469.7314
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 29899.702820000002
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 115430.3134
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 23787.90313
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 137943.9858
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 66839.51271
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 159098.1936
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 74446.9179
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 88470.0
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 96000.0
+    time: unknown
+    sample_id: COVRNA0115
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 7225.779032
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2982.845669
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6520.180288
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1698.2858569999999
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 61189.412580000004
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 18420.71543
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 63609.01798
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 17298.09559
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 32350.0
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1960.0
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 4000.0
+    time: unknown
+    sample_id: COVRNA0334
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0407
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 875.2483661
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0408
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2780.0773900000004
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 310.0
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 117
+    sample_id: COVRNA0536
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1853.9299090000002
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1663.5977639999999
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 117
+    sample_id: COVRNA0537
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0632
+- attributes:
+    age: 49
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 715.2449366
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 722.2371273
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 363.2374078
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 740.0
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 110.0
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0116
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 38629.40303
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5982.387034
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 37125.92767999999
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5679.812056000001
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 32125.80903
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 12900.50045
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 28526.01198
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 14995.95379
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 31150.0
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: E-gRNA-ddPCR-OG
+    value: 28590.0
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 30000.0
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 30000.0
+    time: unknown
+    sample_id: COVRNA0335
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 960.1034161
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0411
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1153.753668
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 250.0
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0412
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 110
+    sample_id: COVRNA0546
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 110
+    sample_id: COVRNA0547
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0635
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 160.0
+    time: 193
+    sample_id: COVRNA0635
+- attributes:
+    age: 38
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3644.4325129999997
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2412.975882
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3553.061214
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5364.011600999999
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4918.756479
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4460.023679
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 730.0
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1040.0
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0117
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0118
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 378.0714254
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0336
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0401
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0402
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1827.309221
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0538
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1052.6074039999999
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0539
+- attributes:
+    age: 32
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 77719.10406000001
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1665.365314
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0521
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0522
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 192
+    sample_id: COVRNA0620
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 192
+    sample_id: COVRNA0621
+- attributes:
+    age: 34
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2424.5262479999997
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1766.282604
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2702.77306
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2857.6952929999998
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3515.436682
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3575.728373
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 450.0
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0119
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 12052.5809
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0403
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 4129.611667
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1113.177826
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0404
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 132
+    sample_id: COVRNA0568
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0630
+- attributes:
+    age: 47
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1691546.482
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 518747.18289999996
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1799397.529
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 530969.1867000001
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2294914.088
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1574702.233
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2571918.673
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1706057.133
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 4041430.0
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 5897130.0
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 21066000.0
+    time: 1
+    sample_id: COVRNA0120
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 21066000.0
+    time: 1
+    sample_id: COVRNA0120
+- attributes:
+    age: 24
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 496.4907317
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 485.2855455
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0121
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0122
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 177.3407287
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0337
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0338
+- attributes:
+    age: 20
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 244936.81509999998
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 58612.80658
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 245762.1135
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 59423.24698
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 255260.4392
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 113173.05570000001
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 240955.14370000002
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 152218.8282
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 198820.0
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 232030.0
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 199000.0
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: 5
+    sample_id: COVRNA0123
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5761.795753
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1858.707631
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5378.082776
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1422.686871
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 40571.5694
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 13355.89555
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 67843.82442
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 11001.20422
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 61770.0
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: E-gRNA-ddPCR-OG
+    value: 10240.0
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0339
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1645.48468
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1619.546943
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0534
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4891.386421
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4736.4896
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 410.0
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0535
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0645
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 193
+    sample_id: COVRNA0645
+- attributes:
+    age: 31
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 829.6333084
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0124
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 688.7633666
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 21
+    sample_id: COVRNA0125
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0340
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 21
+    sample_id: COVRNA0341
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0415
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0416
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1095.446107
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 114
+    sample_id: COVRNA0525
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1426.4355070000001
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2399.247317
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 2720.0
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 114
+    sample_id: COVRNA0526
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0633
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 196
+    sample_id: COVRNA0633
+- attributes:
+    age: 53
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2562.2503939999997
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2682.6932380000003
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 8520.376885
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4486.4641599999995
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7014.663817
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4529.573706
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 6430.0
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 2270.0
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 4000.0
+    time: 0
+    sample_id: COVRNA0126
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 55970.45299
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6782.166193
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 55193.2062
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 7444.051485
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 46705.11047
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 43907.73801
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 54984.09369
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 43754.97049
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 29000.0
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 31860.0
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 53000.0
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 53000.0
+    time: unknown
+    sample_id: COVRNA0127
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5088.1259390000005
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1614.005382
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4051.5268979999996
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 21645.3019
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 10321.90806
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 20318.46462
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 13131.32433
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 9170.0
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 2000.0
+    time: 0
+    sample_id: COVRNA0342
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 596.5295876
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10331.21673
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 993.2192475
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 10672.68993
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 600.8691535
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 6140.0
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0343
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 180.0
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0421
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0422
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1612.796435
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 97
+    sample_id: COVRNA0498
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1070.622219
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 97
+    sample_id: COVRNA0499
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 199
+    sample_id: COVRNA0641
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 210.0
+    time: 199
+    sample_id: COVRNA0641
+- attributes:
+    age: 28
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 98204.02004
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 19404.71077
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 103863.456
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 13550.60623
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 85827.60523
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 46773.451440000004
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 86867.19226
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 43869.28136
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 97940.0
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 102590.0
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 0
+    sample_id: COVRNA0128
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 262471.4966
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 47568.0957
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 217547.1082
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 43368.29514
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 192283.5016
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 128463.5417
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 173792.21860000002
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 155846.6478
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 386180.0
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 416610.0
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 5
+    sample_id: COVRNA0129
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 21852.36758
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 6977.901733000001
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 21116.96101
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 8735.858914
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 94103.85178999999
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 29542.11282
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 86337.09081000001
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 40216.958230000004
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 64930.00000000001
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 22000.0
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 46000.0
+    time: 0
+    sample_id: COVRNA0344
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 825.5533331
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 5
+    sample_id: COVRNA0345
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 73
+    sample_id: COVRNA0423
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0424
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0566
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 128
+    sample_id: COVRNA0567
+- attributes:
+    age: 36
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 43860.32809
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 25143.96441
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 44691.181880000004
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 26169.1911
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 45889.725210000004
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 45849.802670000005
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 57037.797269999995
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 39171.78164
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 21030.0
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 17650.0
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 14000.0
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 53000.0
+    time: unknown
+    sample_id: COVRNA0130
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 627.4300336
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 201.5586023
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 294.3353085
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 358.81684670000004
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0131
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1145.787384
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1454.3931349999998
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 791.7687023999999
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 519.2500279
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 110.0
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0132
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1726.64144
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3789.8281859999997
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2858.8026050000003
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5199.109301
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 450.0
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0346
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 326.19879810000003
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0347
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 684.7829945
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 576.7895748000001
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1388.381932
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 525.8522961
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1448.648506
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 781.739767
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: E-gRNA-ddPCR-OG
+    value: 360.0
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 480.0
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0348
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0425
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 401.5405382
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0426
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 115
+    sample_id: COVRNA0530
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1622.8671880000002
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 115
+    sample_id: COVRNA0531
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1099.543668
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0643
+- attributes:
+    age: 54
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 620175.7238
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 175842.295
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 591725.6706
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 159398.53350000002
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 566845.1418
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 436552.9373
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 574862.3426000001
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 302267.2106
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1639770.0
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1139750.0
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1912000.0
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1912000.0
+    time: unknown
+    sample_id: COVRNA0133
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 26235.48311
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6055.819337
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 30608.648540000002
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 5096.721095999999
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 36455.25187
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 18344.61651
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 35480.25852
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 21008.938319999997
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 11650.0
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 10010.0
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 15000.0
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7000.0
+    time: 10
+    sample_id: COVRNA0134
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6123.150528
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 7855.001164
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 7264.016361999999
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 6582.21275
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 53314.29348
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 14463.816209999999
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 53392.27633
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 16277.7831
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1180.0
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 22580.0
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0349
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 10
+    sample_id: COVRNA0350
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1237.515438
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0427
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 326.9778499
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 245.2989159
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0428
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2356.4272690000003
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1629.8688750000001
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1039.731792
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 103
+    sample_id: COVRNA0504
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3394.367339
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1546.118737
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 17000.0
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 103
+    sample_id: COVRNA0505
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0640
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 120.0
+    time: 198
+    sample_id: COVRNA0640
+- attributes:
+    age: 39
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 288.64514810000003
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0135
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0351
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0429
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 248.3207941
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0430
+- attributes:
+    age: 33
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 953.7400695
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 959.0602049
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1903.90885
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 577.4775847
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1880.4460860000002
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 867.5495873
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 710.0
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0136
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 97864.58877
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 20536.71171
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 104033.2431
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 22259.616130000002
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 128157.55649999999
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 104492.672
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 143318.894
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 94288.2444
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 83800.0
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 81020.0
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 388000.0
+    time: unknown
+    sample_id: COVRNA0137
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 631.0821868999999
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 873.9958684
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 451.68914440000003
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 596.3490094
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 290.0
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0352
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 433.7078131
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 240.7348438
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 318.89311100000003
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 365.12790820000004
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: E-gRNA-ddPCR-OG
+    value: 190.0
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 190.0
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0353
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 191.9415969
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 262.41586379999995
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0431
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1415.816534
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 597.9965371
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 381.40461949999997
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0432
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1753.082153
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1351.2862480000001
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 170.0
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0527
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1943.454546
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1120.397393
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2295.385102
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1148.0714169999999
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0528
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 198
+    sample_id: COVRNA0663
+- attributes:
+    age: 61
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0138
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 557.0300959
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0139
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 7
+    sample_id: COVRNA0354
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5870.919932
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5097.985445
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 5610.8055349999995
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4545.2895770000005
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 29068.24885
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 14707.5071
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 25644.844719999997
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 15640.361990000001
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 8450.0
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0355
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 161.6888717
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0433
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0434
+- attributes:
+    age: 31
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 10722511.8
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1095074.373
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 8983616.49
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 896516.9971
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 9417271.438
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5003015.73
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 9273173.914
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5041966.579
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1000000000.0
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1000000000.0
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 489732000.0
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 489732000.0
+    time: 3
+    sample_id: COVRNA0140
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 694362.4418
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 131542.84050000002
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 727065.6773
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 134364.4485
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1004816.095
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 278065.8972
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1035630.0450000002
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 356502.5941
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: E-gRNA-ddPCR-OG
+    value: 3107060.0
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 9547500.0
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 956000.0
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 1912000.0
+    time: 3
+    sample_id: COVRNA0356
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1005.3538040000001
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 674.2928916000001
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 502.2315288
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 472.2613339
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 22
+    sample_id: COVRNA0387
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 22
+    sample_id: COVRNA0388
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0435
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 530.0
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0436
+- attributes:
+    age: 33
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 381938.23370000004
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 131760.71769999998
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 366173.77520000003
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 126289.5608
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 629637.3507
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 283017.25
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 609891.6473000001
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 271976.7611
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 466910.0
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 782530.0
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1469000.0
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1469000.0
+    time: 2
+    sample_id: COVRNA0141
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 28950.33028
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 14012.97611
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 31972.82446
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 15197.959729999999
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 46953.39988
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 31896.968050000003
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 48379.928759999995
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 35658.55609
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 17640.0
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 10000.0
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 22000.0
+    time: unknown
+    sample_id: COVRNA0142
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1806.3076529999998
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 712.8689353999999
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2119.186779
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1018.1406239999999
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 290.0
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0357
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 3263.785106
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4312.79305
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4345.349697
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1498.2471269999999
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 15648.02082
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2955.9827250000003
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 13896.76637
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4587.077497
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: E-gRNA-ddPCR-OG
+    value: 820.0
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 7050.0
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0358
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0358
+- attributes:
+    age: 32
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 73950.83803999999
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 23773.14809
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 74665.98131
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 22992.07253
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 83581.60104
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 73702.94701999999
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 88992.34242999999
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 62796.59842
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 52290.0
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 53530.0
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 53000.0
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 102000.0
+    time: 15
+    sample_id: COVRNA0143
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 14360.64327
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 15769.69293
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 19925.86074
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 14969.45456
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 42409.34945
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 18734.27341
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 56425.60822
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 19475.329250000003
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: E-gRNA-ddPCR-OG
+    value: 7790.0
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 31590.0
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 15
+    sample_id: COVRNA0359
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 36123.81002
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 7100.732668
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 34540.99211
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 7269.633337
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 121802.3017
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3501.8526890000003
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 125075.7435
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3060.821614
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 108400.0
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0442
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 175480.3979
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 47117.46453
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 163213.0397
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 50407.11732
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 308459.0802
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 59769.05378
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 274372.3373
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 75317.57635
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 202840.0
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 129000.0
+    time: 27
+    sample_id: COVRNA0443
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 129000.0
+    time: 27
+    sample_id: COVRNA0443
+- attributes:
+    age: 54
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 3
+    sample_id: COVRNA0144
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 516.7557775
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 120.0
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0145
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 323.99346829999996
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 224.4368496
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 297.3401807
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 170.0
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: E-gRNA-ddPCR-OG
+    value: 90.0
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0360
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0361
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1716.1367679999998
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0440
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2858.167014
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0441
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0508
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1148.729607
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1220.014518
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0509
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0644
+- attributes:
+    age: 33
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 25112.57942
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2216.3657909999997
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 22382.5086
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2867.108356
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 44986.9772
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 11375.10285
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 50664.779449999995
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 15313.50567
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 45690.0
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 29510.0
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 27000.0
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 27000.0
+    time: unknown
+    sample_id: COVRNA0146
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 31777.27966
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 13619.39588
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 31112.27044
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 12956.50837
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 72663.83247000001
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 27561.87404
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 73853.86433
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 22511.086349999998
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 49920.0
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 5000.0
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 10000.0
+    time: unknown
+    sample_id: COVRNA0147
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4168.829629
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1105.987508
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4773.905095
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 817.5137096000001
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 96303.05734
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 57573.859919999995
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 97078.98769000001
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 46751.31882
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 183310.0
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: E-gRNA-ddPCR-OG
+    value: 5600.0
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0362
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1562.662135
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 998.5119103
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1889.698445
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 812.0867704
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 14395.20413
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5281.799712999999
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 12972.91141
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3610.467408
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 9310.0
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: E-gRNA-ddPCR-OG
+    value: 610.0
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0363
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 31
+    sample_id: COVRNA0452
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2234.9408839999996
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 150.0
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 31
+    sample_id: COVRNA0453
+- attributes:
+    age: 71
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3286.689771
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 790.3910575000001
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 4243.950004
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 6927.64967
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4441.35476
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7045.5037520000005
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3692.6119759999997
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 5000.0
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 3860.0
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 4000.0
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0148
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 42562.20168
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3991.070454
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 37401.655810000004
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3725.8006419999997
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 48029.71815
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 43618.38496
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 40647.50238
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 41681.86101
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 28460.0
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 31840.0
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 27000.0
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 27000.0
+    time: unknown
+    sample_id: COVRNA0149
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 3139.434037
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2345.3208929999996
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 36108.74699
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4303.361889
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 36350.33268
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 5296.54871
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1240.0
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 33870.0
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0365
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0365
+- attributes:
+    age: 34
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 27346.51674
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 8817.402745000001
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 31875.1824
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 7598.749148
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 32020.334069999997
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 18223.75996
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 37480.584370000004
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 21542.57753
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 15510.0
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 16200.0
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 30000.0
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 15000.0
+    time: 0
+    sample_id: COVRNA0150
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 4726.063581
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4758.874995
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6286.566857999999
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1251.542245
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 23231.89444
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 34789.11447
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 11496.33157
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: E-gRNA-ddPCR-OG
+    value: 1640.0
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 8620.0
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0366
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 25
+    sample_id: COVRNA0445
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 28
+    sample_id: COVRNA0446
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1168.12441
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0532
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1182.241709
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0533
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 231
+    sample_id: COVRNA0669
+- attributes:
+    age: 30
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0367
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 843.7416303
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 28
+    sample_id: COVRNA0447
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1082.3634849999999
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1158.13905
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 107
+    sample_id: COVRNA0529
+- attributes:
+    age: 47
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 470.0
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0368
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0369
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1527.555568
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0444
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1148.594267
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1127.071698
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 95
+    sample_id: COVRNA0518
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 193
+    sample_id: COVRNA0639
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 240.0
+    time: 193
+    sample_id: COVRNA0639
+- attributes:
+    age: 66
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 953.7076392
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 420.0
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0151
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 0
+    sample_id: COVRNA0370
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 168.2206692
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0437
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0451
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 102
+    sample_id: COVRNA0557
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 102
+    sample_id: COVRNA0558
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 196
+    sample_id: COVRNA0648
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 150.0
+    time: 196
+    sample_id: COVRNA0648
+- attributes:
+    age: 35
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 610352.3359
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 154682.0174
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 601193.3972
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 144478.24610000002
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 697556.8634
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 602583.4721
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 689152.5102
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 562706.3049
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 1216130.0
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 3938000.0
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 3938000.0
+    time: 2
+    sample_id: COVRNA0152
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 12981.17922
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 5447.287192
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 11624.53737
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 6255.309325
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 94219.4853
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 45284.29206
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 86503.68317
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 61656.15169
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 64890.0
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 5000.0
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 2000.0
+    time: 2
+    sample_id: COVRNA0371
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3285.848264
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6277.509730000001
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 980.0
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 27
+    sample_id: COVRNA0448
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 10565.470469999998
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3266.702753
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 13536.83827
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 19398.94481
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4000.428374
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 15911.30447
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5018.8485439999995
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 6390.0
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0449
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 90.0
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0553
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 112
+    sample_id: COVRNA0554
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 224
+    sample_id: COVRNA0657
+- attributes:
+    age: 36
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 8058.4065630000005
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2628.174614
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 7678.196873
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2200.438351
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 9325.801703
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 5331.541519
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 12002.95565
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4066.009889
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 3000.0
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 1970.0
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7000.0
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 4000.0
+    time: 2
+    sample_id: COVRNA0153
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 6856.504878
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1950.682305
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 7242.611241
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1499.47674
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 9735.635818
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 6393.603763
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 9694.009882
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 7370.031937000001
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 9130.0
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: E-gRNA-ddPCR-OG
+    value: 5610.0
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0372
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0549
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 119
+    sample_id: COVRNA0573
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 119
+    sample_id: COVRNA0574
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 184
+    sample_id: COVRNA0631
+- attributes:
+    age: 61
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2716.1058580000004
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2069.626798
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1071.0560090000001
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 7018.403573
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2220.3147950000002
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 5914.487256
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1571.297851
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 940.0
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 5000.0
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 10000.0
+    time: unknown
+    sample_id: COVRNA0154
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 818.0575646
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 932.2785994000001
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3322.690474
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 252.88780379999997
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2881.502059
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 401.8553757
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: E-gRNA-ddPCR-OG
+    value: 810.0
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 4070.0000000000005
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0373
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 15418.644090000002
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 230.67835079999998
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 299.2952091
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 150.0
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0389
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 170.0
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0390
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 100.0
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0555
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0556
+- attributes:
+    age: 32
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 99716.98032
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 27188.19674
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 112593.7295
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 25554.78859
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 121332.6164
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 103422.25379999999
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 139306.0084
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 91201.39938
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 78590.0
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 86020.0
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 119000.0
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 239000.0
+    time: 3
+    sample_id: COVRNA0155
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 358.5351899
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 631.1773519
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 462.8894815
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 166.64703110000002
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 210.0
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0374
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6149.031808
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1971.109782
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 6217.159037
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2135.208843
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 2630.0
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0391
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2231119.002
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 290.0
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0392
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0457
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4799.56983
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 610.0
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0458
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0575
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0576
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 197
+    sample_id: COVRNA0662
+- attributes:
+    age: 18
+    sex: female
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1653.227211
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1124.047067
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 110.0
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0156
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 182.6178281
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 180.0
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0375
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2489.4528290000003
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2457.61103
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 886.266726
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 11027.397710000001
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 3677.049814
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 11730.65497
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 4043.85538
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 5810.0
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0393
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 14943.96139
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 7623.541372
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 15296.00391
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6861.295773
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 15817.017829999999
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 11922.298509999999
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 20199.178939999998
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 12461.9313
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 4019.9999999999995
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0394
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 22000.0
+    time: unknown
+    sample_id: COVRNA0394
+- attributes:
+    age: 62
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 740.8510129
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1668.8764330000001
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1263.432226
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 340.0
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 1
+    sample_id: COVRNA0376
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 2440.9858670000003
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2402.179637
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 2813.370247
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4427.4603609999995
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2005.9659629999999
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 4173.336735000001
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 1593.40129
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 910.0
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0395
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 14467.207719999999
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3876.926252
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 16712.13881
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1426.940531
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 19038.728639999998
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 13442.77369
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 19909.62584
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 15274.279410000001
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 7530.0
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0396
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0454
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 104
+    sample_id: COVRNA0550
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1785.3269810000002
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 111
+    sample_id: COVRNA0559
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 111
+    sample_id: COVRNA0560
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 195
+    sample_id: COVRNA0654
+- attributes:
+    age: 53
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 14
+    sample_id: COVRNA0419
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2405.224181
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 896.4934668999999
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 27
+    sample_id: COVRNA0459
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 8000.0
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 106
+    sample_id: COVRNA0540
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 110.0
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 106
+    sample_id: COVRNA0541
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 210
+    sample_id: COVRNA0653
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 250.0
+    time: 210
+    sample_id: COVRNA0653
+- attributes:
+    age: 41
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 58202.91585
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 14030.361040000002
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 55555.96131
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 12939.06788
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 54985.49806
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 37536.1004
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 56276.275830000006
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 34153.109370000006
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 48630.0
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 46550.0
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1912000.0
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 1912000.0
+    time: unknown
+    sample_id: COVRNA0157
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 127028.187
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 15353.088310000001
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 134819.1375
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 28144.500640000002
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 186639.3587
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 142290.8327
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 155838.6408
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 187997.3376
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 106520.0
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7486000.0
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 7486000.0
+    time: 13
+    sample_id: COVRNA0417
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0460
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2814.0295260000003
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 116
+    sample_id: COVRNA0562
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 116
+    sample_id: COVRNA0563
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1704.049526
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 2700.8608280000003
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 4276.881448
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 3005.077186
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3019.26747
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 5439.381989
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 5248.59067
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6478.237993
+    time: 193
+    sample_id: COVRNA0638
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 300.0
+    time: 193
+    sample_id: COVRNA0638
+- attributes:
+    age: 37
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2036.527505
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 65367.66029
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0461
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 112
+    sample_id: COVRNA0561
+- attributes:
+    age: 22
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2352.064531
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1237.5069
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 1890.378179
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1469.083783
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3638.213687
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1901.694558
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1914.1149719999999
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1483.81012
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 690.0
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0158
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 446.52114059999997
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 543.5932354
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 696.0531099
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 100.0
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0377
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0462
+- attributes:
+    age: 60
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 139
+    sample_id: COVRNA0583
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 139
+    sample_id: COVRNA0584
+- attributes:
+    age: 56
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 243.7291375
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 13
+    sample_id: COVRNA0438
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 155
+    sample_id: COVRNA0605
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 155
+    sample_id: COVRNA0606
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 176
+    sample_id: COVRNA0615
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 130.0
+    time: 176
+    sample_id: COVRNA0615
+- attributes:
+    age: 54
+    sex: male
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 78669.67047
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 9982.723261000001
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 90166.47792
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 6925.260343999999
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 53972.61937
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 23422.23615
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 50282.87565
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 24690.146859999997
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: E-gRNA-ddPCR-ZY
+    value: 81760.0
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 66150.0
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 60000.0
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 60000.0
+    time: 3
+    sample_id: COVRNA0159
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 7855.970623
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 3808.294119
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 8671.949702999998
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 3630.452813
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 21935.310980000002
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2355.51304
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 22743.439680000003
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2793.459175
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 14790.0
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 3
+    sample_id: COVRNA0378
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 49192.92452
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 14614.69383
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 34880.860239999995
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 14724.453860000001
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 73936.6908
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 39832.7028
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 75833.58280999999
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 39298.71335
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 109800.0
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 46000.0
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 22000.0
+    time: unknown
+    sample_id: COVRNA0397
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 168112.9941
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 28057.63206
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 188442.08750000002
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 32603.24835
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 183218.0706
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 146512.1192
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 189411.3343
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 127488.9789
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 194420.0
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 425000.0
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: 425000.0
+    time: unknown
+    sample_id: COVRNA0398
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 5714.544945
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 3985.008972
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 6952.856339
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1328.8863820000001
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 8464.401924
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1661.466663
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 980.0
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 20
+    sample_id: COVRNA0450
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 20556.609389999998
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 20152.086610000002
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 20955.12169
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 4355.148609
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 21589.9413
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 6340.7168870000005
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 2330.0
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 75
+    sample_id: COVRNA0482
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 128
+    sample_id: COVRNA0585
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 222
+    sample_id: COVRNA0656
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 70.0
+    time: 222
+    sample_id: COVRNA0656
+- attributes:
+    age: 34
+    sex: male
+    study_arm: test
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 36818.43553
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 9348.262121
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 31737.09822
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 8689.682594
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 125580.992
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 47035.63259
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 126197.1195
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 60807.55777
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 156030.0
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: E-gRNA-ddPCR-OG
+    value: 27030.0
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 14000.0
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: 7000.0
+    time: 3
+    sample_id: COVRNA0379
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 39286.36766
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 9494.267593
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 42763.241890000005
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 4181.27916
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 67507.84883999999
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 29197.78542
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 67143.17216
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 40831.9593
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 115730.0
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0409
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 1087.6295010000001
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 5033.001364000001
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1155.5990140000001
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 3843.084179
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1137.72532
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 800.0
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0410
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 3569.146217
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: 2447.8288820000002
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 843.3494496000001
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1033.846324
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 2467.403365
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1608.9645429999998
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 590.0
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0463
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0569
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0667
+- attributes:
+    age: 31
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 706.6435885999999
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: 1462.4386410000002
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: 1391.9946439999999
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 2823.618647
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 2315.998238
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 3914.319487
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: 633.6726516
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 570.0
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0380
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1452.857808
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0418
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0464
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 55
+    sample_id: COVRNA0516
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: 1116.240919
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 55
+    sample_id: COVRNA0517
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 113
+    sample_id: COVRNA0570
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0664
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: 80.0
+    time: 204
+    sample_id: COVRNA0664
+- attributes:
+    age: 44
+    sex: female
+    study_arm: control
+  measurements:
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: E-gRNA-ddPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 2
+    sample_id: COVRNA0160
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: E-gRNA-ddPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N1-gRNA-ddPCR-OG
+    value: 90.0
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 2
+    sample_id: COVRNA0381
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: unknown
+    sample_id: COVRNA0455
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 2192.189099
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: 1263.620392
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0456
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: 273092.78010000003
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: 1416.6500680000001
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: unknown
+    sample_id: COVRNA0465
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: N1-sgRNA-RT-qPCR-ZY
+    value: negative
+    time: 120
+    sample_id: COVRNA0579
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: E-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: RdRP-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N1-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N2-gRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N1-gRNA-ddPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N1-sgRNA-RT-qPCR-OG
+    value: negative
+    time: 120
+    sample_id: COVRNA0580
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: N1-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: N2-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: E-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: RdRP-gRNA-RT-qPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652
+  - analyte: N1-gRNA-ddPCR-ZY
+    value: negative
+    time: 204
+    sample_id: COVRNA0652

--- a/data/natarajan2022.yaml
+++ b/data/natarajan2022.yaml
@@ -20,88 +20,144 @@ analytes:
   E-gRNA-RT-qPCR-OG:
     description: Concentration of genomic RNA of the E gene quantified using RT-qPCR
       for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: E
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   E-gRNA-RT-qPCR-ZY:
     description: Concentration of genomic RNA of the E gene quantified using RT-qPCR
       for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: E
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   RdRP-gRNA-RT-qPCR-OG:
     description: Concentration of genomic RNA of the RdRp gene quantified using RT-qPCR
       for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: RdRP
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   RdRP-gRNA-RT-qPCR-ZY:
     description: Concentration of genomic RNA of the RdRp gene quantified using RT-qPCR
       for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: RdRP
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N1-gRNA-RT-qPCR-OG:
     description: Concentration of genomic RNA of the N1 gene quantified using RT-qPCR
       for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N1
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N1-gRNA-RT-qPCR-ZY:
     description: Concentration of genomic RNA of the N1 gene quantified using RT-qPCR
       for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N1
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N2-gRNA-RT-qPCR-OG:
     description: Concentration of genomic RNA of the N2 gene quantified using RT-qPCR
       for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N2
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N2-gRNA-RT-qPCR-ZY:
     description: Concentration of genomic RNA of the N2 gene quantified using RT-qPCR
       for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N2
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N1-gRNA-ddPCR-OG:
     description: Concentration of genomic RNA of the N1 gene quantified using ddPCR
       for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N1
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N1-gRNA-ddPCR-ZY:
     description: Concentration of genomic RNA of the N1 gene quantified using ddPCR
       for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N1
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   E-gRNA-ddPCR-OG:
     description: Concentration of genomic RNA of the E gene quantified using ddPCR
       for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: E
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   E-gRNA-ddPCR-ZY:
     description: Concentration of genomic RNA of the E gene quantified using ddPCR
       for a sample collected using the Zymo DNA/RNA shield fecal collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: E
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N1-sgRNA-RT-qPCR-OG:
     description: Concentration of sub-genomic RNA of the N1 gene quantified using
       RT-qPCR for a sample collected using the OMNIGene GUT collection tube.
+    biomarker: SARS-CoV-2
+    gene_target: N1
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
   N1-sgRNA-RT-qPCR-ZY:
     description: Concentration of sub-genomic RNA of the N1 gene quantified using
       RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal collection
       tube.
+    biomarker: SARS-CoV-2
+    gene_target: N1
+    unit: gc/mL
     specimen: stool
     limit_of_detection: 1000
     limit_of_quantification: unknown
+    reference_event: enrollment
 participants:
 - attributes:
     age: 55

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "shedding-hub"
+version = "0.1.0"
+readme = "README.md"
+description = "Data and statistical models for biomarker shedding."
+
+[tool.setuptools.packages]
+find = {}

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,10 @@
+-e file:.
 black
 matplotlib
 jupyter
 jupytext
 jsonschema
+pandas
 pip-tools
 pyaml
 pymupdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile
 #
+-e file:.
+    # via -r requirements.in
 anyio==4.4.0
     # via
     #   httpx
@@ -213,6 +215,7 @@ numpy==2.0.1
     # via
     #   contourpy
     #   matplotlib
+    #   pandas
 overrides==7.7.0
     # via jupyter-server
 packaging==24.1
@@ -229,6 +232,8 @@ packaging==24.1
     #   pytest
     #   qtconsole
     #   qtpy
+pandas==2.2.2
+    # via -r requirements.in
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -288,8 +293,11 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   jupyter-client
     #   matplotlib
+    #   pandas
 python-json-logger==2.0.7
     # via jupyter-events
+pytz==2024.1
+    # via pandas
 pyyaml==6.0.1
     # via
     #   jupyter-events
@@ -376,6 +384,8 @@ types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.12.2
     # via ipython
+tzdata==2024.1
+    # via pandas
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2

--- a/shedding_hub/__init__.py
+++ b/shedding_hub/__init__.py
@@ -1,0 +1,5 @@
+from .util import normalize_str
+
+__all__ = [
+    "normalize_str",
+]

--- a/shedding_hub/util.py
+++ b/shedding_hub/util.py
@@ -1,0 +1,23 @@
+import re
+import textwrap
+
+
+def normalize_str(
+    value: str, *, dedent: bool = True, strip: bool = True, unwrap: bool = True
+) -> str:
+    """
+    Normalize a string.
+
+    Args:
+        value: String to normalize.
+        dedent: Remove any common leading whitespace.
+        strip: Remove leading and trailing whitespace.
+        unwrap: Unwrap lines separated by a single line break.
+    """
+    if dedent:
+        value = textwrap.dedent(value)
+    if unwrap:
+        value = re.sub(r"(?<!\n) *\n(?!\n)", " ", value)
+    if strip:
+        value = value.strip()
+    return value

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 import jsonschema
+import numpy as np
 from pathlib import Path
 import pytest
 import yaml
@@ -48,6 +49,13 @@ def load_and_validate(path: Path):
                     f"Measurement {j} for patient {i} declares the invalid analyte "
                     f"`{measurement['analyte']}`."
                 )
+
+            value = measurement["value"]
+            if not isinstance(value, str) and np.isnan(value):
+                raise ValueError(f"Measurement {j} for patient {i} has nan `value`.")
+            time = measurement.get("time", 0)
+            if not isinstance(time, str) and np.isnan(time):
+                raise ValueError(f"Measurement {j} for patient {i} has nan `time`.")
 
     if has_analytes:
         used_analytes = {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,4 +18,3 @@ from shedding_hub import util
 )
 def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
     assert util.normalize_str(value, **kwargs) == expected
-

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,21 @@
+import pytest
+from shedding_hub import util
+
+
+@pytest.mark.parametrize(
+    "value, kwargs, expected",
+    [
+        ("    asdf\n    jkl;", {}, "asdf jkl;"),
+        ("    asdf\n    jkl;", {"dedent": False}, "asdf     jkl;"),
+        ("    asdf\n    jkl;", {"dedent": False, "strip": False}, "    asdf     jkl;"),
+        ("    asdf\n    jkl;", {"dedent": False, "unwrap": False}, "asdf\n    jkl;"),
+        (
+            "    asdf\n    jkl;",
+            {"dedent": False, "unwrap": False, "strip": False},
+            "    asdf\n    jkl;",
+        ),
+    ],
+)
+def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
+    assert util.normalize_str(value, **kwargs) == expected
+

--- a/tutorials/natarajan2022-extraction.md
+++ b/tutorials/natarajan2022-extraction.md
@@ -1,0 +1,241 @@
+# Extraction for Natarajan et al. (2022)
+
+[Natarajan et al. (2022)](https://doi.org/10.1016/j.medj.2022.04.001) quantified fecal shedding of different SARS-CoV-2 gene targets in feces for 113 individuals, and their data are published across several files in a [GitHub repository](https://github.com/alex-dahlen/lambda_fecal_shedding/). For reproducibility, we consider commit `7affa71`. They obtained diverse data using different sample collection kits, different gene targets, and different quantification methods.
+
+```python
+import pandas as pd
+import yaml
+import shedding_hub as sh
+```
+
+```python
+# We load baseline data including demographics, the sample index mapping samples to
+# participants.
+base_url = "https://github.com/alex-dahlen/lambda_fecal_shedding/raw/7affa71/"
+baseline = pd.read_csv(
+    base_url + "Source%20Data/Source%20data_modified.xlsx%20-%20Baseline%20data.csv",
+    index_col="Participant ID",
+)
+index = pd.read_csv(
+    base_url + "Source%20Data/Source%20data_modified.xlsx%20-%20Index%20of%20clinical"
+    "%20stool%20samples.csv",
+    skiprows=3,
+    parse_dates=["Date of sample collection", "Date of subject enrollment"],
+    dayfirst=False,
+)
+
+# The raw data is grouped by assay type: sgRNA (subgenomic RNA by RT-qPCR), gRNA
+# (genomic RNA by RT-qPCR), ddPCR (genomic RNA).
+suffix_by_assay = {
+    "gRNA-RT-qPCR": "Raw%20RT_qPCR%20gRNA%20data",
+    "gRNA-ddPCR": "Raw%20ddPCR%20gRNA%20data",
+    "sgRNA-RT-qPCR": "Raw%20RT-qPCR%20sgRNA%20data",
+}
+
+# Combine all the different datasets into one large raw dataset.
+parts = []
+for key, value in suffix_by_assay.items():
+    raw = pd.read_csv(
+        f"{base_url}Source%20Data/Source%20data_modified.xlsx%20-%20{value}.csv",
+        skiprows=3,
+    )
+    # Subgenomic RNA was only targeting the N1 gene as described in the section "RT-qPCR
+    # quantification of RNA".
+    raw["analyte"] = (raw["Target gene"] if "Target gene" in raw else "N1") + "-" + key
+    parts.append(raw)
+raw = pd.concat(parts)
+```
+
+```python
+# Merge the data and ensure we didn't gain or lose any samples. Then update the analyte
+# definition.
+merged = pd.merge(index, raw, on="RNA sample ID", how="outer")
+assert merged.shape[0] == raw.shape[0]
+merged["analyte"] = merged.analyte + "-" + merged["Stool preservative"]
+
+participants = []
+for subject_id, subset in merged.groupby("Subject study ID"):
+    subject = baseline.loc[subject_id]
+
+    participants.append(
+        {
+            "attributes": {
+                "age": int(subject.Age),
+                # This coding is based on manually comparing the {0, 1} coding of `Sex`
+                # here with the `male` column in the `demographics.xlsx` spreadsheet.
+                "sex": "female" if subject.Sex else "male",
+                "study_arm": (
+                    "test" if subject["Arm of study"] == "Lambda" else "control"
+                ),
+            },
+            "measurements": [
+                {
+                    "analyte": row.analyte,
+                    "value": (
+                        "negative"
+                        if (value := row["Viral RNA concentration (copies/μL)"]) == 0
+                        else 1e3 * value
+                    ),
+                    "time": (
+                        "unknown"
+                        if pd.isnull(
+                            days := (
+                                row["Date of sample collection"]
+                                - row["Date of subject enrollment"]
+                            ).days
+                        )
+                        else days
+                    ),
+                    "sample_id": row["RNA sample ID"],
+                }
+                for _, row in subset.iterrows()
+            ],
+        }
+    )
+
+```
+
+```python
+description = sh.normalize_str(
+    """
+    Fecal samples were collected from 113 participants "in a randomized controlled study
+    of Peg-interferon lambda-1a versus a placebo control for the treatment of mild to
+    moderate COVID-19." A total of 7,563 measurements were taken for 679 samples using
+    seven distinct assays; assays were typically run in duplicates.
+
+    Samples were
+    initially collected using OMNIGene GUT collection tubes (OG) but subsequently
+    replaced with Zymo DNA/RNA shield fecal collection tubes (ZY) because of better
+    performance. There are consequently 14 analytes following the naming convention
+    `{target gene E, RdRP, N1, or N2}-{genomic RNA (gRNA) or subgenomic RNA
+    (sgRNA)}-{quantification method RT-qPCR or ddPCR}-{collection tube OG or ZY}`.
+
+    The reference event for temporal offsets in days is the day of enrollment.
+    """
+)
+data = {
+    "title": "Gastrointestinal symptoms and fecal shedding of SARS-CoV-2 RNA suggest "
+    "prolonged gastrointestinal infection",
+    "doi": "10.1016/j.medj.2022.04.001",
+    "description": description,
+    "analytes": {
+        "E-gRNA-RT-qPCR-OG": {
+            "description": "Concentration of genomic RNA of the E gene quantified "
+            "using RT-qPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "E-gRNA-RT-qPCR-ZY": {
+            "description": "Concentration of genomic RNA of the E gene quantified "
+            "using RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "RdRP-gRNA-RT-qPCR-OG": {
+            "description": "Concentration of genomic RNA of the RdRp gene quantified "
+            "using RT-qPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "RdRP-gRNA-RT-qPCR-ZY": {
+            "description": "Concentration of genomic RNA of the RdRp gene quantified "
+            "using RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N1-gRNA-RT-qPCR-OG": {
+            "description": "Concentration of genomic RNA of the N1 gene quantified "
+            "using RT-qPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N1-gRNA-RT-qPCR-ZY": {
+            "description": "Concentration of genomic RNA of the N1 gene quantified "
+            "using RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N2-gRNA-RT-qPCR-OG": {
+            "description": "Concentration of genomic RNA of the N2 gene quantified "
+            "using RT-qPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N2-gRNA-RT-qPCR-ZY": {
+            "description": "Concentration of genomic RNA of the N2 gene quantified "
+            "using RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N1-gRNA-ddPCR-OG": {
+            "description": "Concentration of genomic RNA of the N1 gene quantified "
+            "using ddPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N1-gRNA-ddPCR-ZY": {
+            "description": "Concentration of genomic RNA of the N1 gene quantified "
+            "using ddPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "E-gRNA-ddPCR-OG": {
+            "description": "Concentration of genomic RNA of the E gene quantified "
+            "using ddPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "E-gRNA-ddPCR-ZY": {
+            "description": "Concentration of genomic RNA of the E gene quantified "
+            "using ddPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N1-sgRNA-RT-qPCR-OG": {
+            "description": "Concentration of sub-genomic RNA of the N1 gene quantified "
+            "using RT-qPCR for a sample collected using the OMNIGene GUT collection "
+            "tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+        "N1-sgRNA-RT-qPCR-ZY": {
+            "description": "Concentration of sub-genomic RNA of the N1 gene quantified "
+            "using RT-qPCR for a sample collected using the Zymo DNA/RNA shield fecal "
+            "collection tube.",
+            "specimen": "stool",
+            "limit_of_detection": 1000,
+            "limit_of_quantification": "unknown",
+        },
+    },
+    "participants": participants,
+}
+
+with open("../data/natarajan2022.yaml", "w") as fp:
+    fp.write("# yaml-language-server: $schema=.schema.yaml\n")
+    yaml.dump(data, fp, sort_keys=False)
+```


### PR DESCRIPTION
This PR adds data from Natarajan et al. (2022) and closes #8. It also adds a package for utility functions and updates the schema by adding an optional `sample_id` field for each measurement. This can be used to group measurements for the same sample. E.g., in Natarajan et al. (2022), SARS-CoV-2 RNA is quantified using different target genes (E, N1, N2, RdRP) and different assays (RT-qPCR, ddPCR).

I've added another "tutorial" notebook illustrating how the data were extracted from the [associated repository](https://github.com/alex-dahlen/lambda_fecal_shedding/). Not sure if the `tutorials` folder is the right place for these notebooks. What do you think?