### PR TITLE
Expand analyte metadata.

### DIFF
--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -33,14 +33,37 @@ $defs:
         description: Specimen type.
         type: string
         enum:
-        - stool
-        - sputum
-        - throat_swab
+          - stool
+          - sputum
+          - throat_swab
+      biomarker:
+        description: Biomarker being measured.
+        type: string
+        enum:
+          - SARS-CoV-2
+          - mtDNA
+          - PMMoV
+      unit:
+        description: Units in which measurements are reported.
+        type: string
+        enum:
+          - gc/dry gram
+          - gc/mL
+          - gc/swab
+          - gc/wet gram
+      reference_event:
+        description: Event used as reference for `time` fields of measurements.
+        type: string
+        enum:
+          - symptom onset
     required:
+      - biomarker
       - description
       - limit_of_detection
       - limit_of_quantification
+      - reference_event
       - specimen
+      - unit
 
 type: object
 additionalProperties: false
@@ -131,6 +154,6 @@ required:
 # Require that either url or doi are given.
 oneOf:
   - required:
-    - url
+      - url
   - required:
-    - doi
+      - doi

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -56,6 +56,7 @@ $defs:
         type: string
         enum:
           - symptom onset
+          - confirmation date
     required:
       - biomarker
       - description

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -146,6 +146,7 @@ properties:
               analyte:
                 type: string
             required:
+              - time
               - value
 required:
   - description

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -43,6 +43,11 @@ $defs:
           - SARS-CoV-2
           - mtDNA
           - PMMoV
+      gene_target:
+        description: The gene being targeted in qPCR or ddPCR if a genomic biomarker.
+          This field should be left empty for non-genomic biomarkers, e.g., drug
+          metabolites.
+        type: string
       unit:
         description: Units in which measurements are reported.
         type: string

--- a/data/woelfel2020.yaml
+++ b/data/woelfel2020.yaml
@@ -19,6 +19,7 @@ analytes:
     limit_of_detection: unknown
     specimen: stool
     biomarker: SARS-CoV-2
+    gene_target: E and RdRP (not further specified by authors)
     unit: gc/mL
     reference_event: symptom onset
   sputum:
@@ -29,6 +30,7 @@ analytes:
     limit_of_detection: unknown
     specimen: sputum
     biomarker: SARS-CoV-2
+    gene_target: E and RdRP (not further specified by authors)
     unit: gc/mL
     reference_event: symptom onset
   throat_swab:
@@ -38,6 +40,7 @@ analytes:
     limit_of_detection: unknown
     specimen: throat_swab
     biomarker: SARS-CoV-2
+    gene_target: E and RdRP (not further specified by authors)
     unit: gc/swab
     reference_event: symptom onset
 participants:

--- a/data/woelfel2020.yaml
+++ b/data/woelfel2020.yaml
@@ -18,6 +18,9 @@ analytes:
     limit_of_quantification: 100
     limit_of_detection: unknown
     specimen: stool
+    biomarker: SARS-CoV-2
+    unit: gc/mL
+    reference_event: symptom onset
   sputum:
     description: >
       RNA gene copy concentration in sputum samples. Results are reported as gene copies
@@ -25,12 +28,18 @@ analytes:
     limit_of_quantification: 100
     limit_of_detection: unknown
     specimen: sputum
+    biomarker: SARS-CoV-2
+    unit: gc/mL
+    reference_event: symptom onset
   throat_swab:
     description: >
       Number of gene copies per throat swab.
     limit_of_quantification: 100
     limit_of_detection: unknown
     specimen: throat_swab
+    biomarker: SARS-CoV-2
+    unit: gc/swab
+    reference_event: symptom onset
 participants:
 - measurements:
   - analyte: sputum

--- a/tests/examples/valid_multiple_analytes.yaml
+++ b/tests/examples/valid_multiple_analytes.yaml
@@ -8,11 +8,17 @@ analytes:
     limit_of_quantification: 17
     description: One analyte.
     specimen: stool
+    biomarker: mtDNA
+    reference_event: symptom onset
+    unit: gc/wet gram
   analyte2:
     limit_of_detection: unknown
     limit_of_quantification: 17
     description: Another analyte.
     specimen: sputum
+    biomarker: PMMoV
+    reference_event: symptom onset
+    unit: gc/dry gram
 participants:
   - attributes:
       sex: female

--- a/tests/examples/valid_multiple_analytes.yaml
+++ b/tests/examples/valid_multiple_analytes.yaml
@@ -17,7 +17,7 @@ analytes:
     description: Another analyte.
     specimen: sputum
     biomarker: PMMoV
-    reference_event: symptom onset
+    reference_event: confirmation date
     unit: gc/dry gram
 participants:
   - attributes:

--- a/tests/examples/valid_multiple_analytes.yaml
+++ b/tests/examples/valid_multiple_analytes.yaml
@@ -26,9 +26,11 @@ participants:
     measurements:
     - value: 3
       analyte: analyte1
+      time: -3.5
   - attributes:
       sex: male
       age: 87
     measurements:
     - value: 1
       analyte: analyte2
+      time: 9

--- a/tests/examples/valid_single_analyte.yaml
+++ b/tests/examples/valid_single_analyte.yaml
@@ -7,6 +7,9 @@ analyte:
   limit_of_quantification: 17
   description: A single analyte.
   specimen: stool
+  biomarker: PMMoV
+  reference_event: symptom onset
+  unit: gc/dry gram
 participants:
   - attributes:
       sex: female

--- a/tests/examples/valid_single_analyte.yaml
+++ b/tests/examples/valid_single_analyte.yaml
@@ -17,3 +17,4 @@ participants:
       arbitrary_attribute: This is some unstructured text that is not validated.
     measurements:
     - value: 3
+      time: 7


### PR DESCRIPTION
This PR expands analyte metadata and closes #12. It updates the Wölfel et al. (2020) dataset and example files in the `tests/examples` folder to comply with the updated schema. I went for `reference_event` instead of `date_of_reference` because the data type (e.g., "symptom onset", "hospital admission", or "confirmation") is an event as opposed to a date. Open to other naming conventions if you prefer another?