### PR TITLE
Add trigger to build shedding-hub.github.io.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,15 @@ jobs:
       run: black --check .
     - name: Run tests
       run: pytest -v
+
+  # This job will trigger the GitHub pages build for shedding-hub.github.io.
+  deploy-pages:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: shedding-hub/shedding-hub.github.io
+          event-type: dispatch-event


### PR DESCRIPTION
I've created a basic website for our project at [shedding-hub.github.io](https://shedding-hub.github.io) which we can expand at a later point. This PR adds a trigger such that website is re-built every time we add or update data. 

The "1 studies" grammatical error will be fixed once we merge another dataset.

I've not previously used these cross-repository triggers so the process may need some iteration.