### PR TITLE
Only deploy GitHub Pages from `main` branch.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
 
   # This job will trigger the GitHub pages build for shedding-hub.github.io.
   deploy-pages:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
I forgot to add a condition to the deploy step for https://shedding-hub.github.io in #15. So the website is re-deployed every time a PR is opened or updated. This will ensure the page is only deployed when there are changes to the `main` branch.