### PR TITLE
Add utility function `load_dataset` to reproducibly load data.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: Lint code
         run: black --check .
       - name: Run tests
-        run: pytest -v
+        run: pytest -v --cov=shedding_hub --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ name = "shedding-hub"
 version = "0.1.0"
 readme = "README.md"
 description = "Data and statistical models for biomarker shedding."
+dependencies = [
+    "pyaml",
+    "requests",
+]
 
 [tool.setuptools.packages]
 find = {}

--- a/requirements.in
+++ b/requirements.in
@@ -9,3 +9,4 @@ pip-tools
 pyaml
 pymupdf
 pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,8 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.3.0
     # via matplotlib
+coverage[toml]==7.6.1
+    # via pytest-cov
 cycler==0.12.1
     # via matplotlib
 debugpy==1.8.5
@@ -264,7 +266,9 @@ ptyprocess==0.7.0
 pure-eval==0.2.3
     # via stack-data
 pyaml==24.7.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   shedding-hub
 pycparser==2.22
     # via cffi
 pygments==2.18.0
@@ -283,6 +287,10 @@ pyproject-hooks==1.1.0
     #   build
     #   pip-tools
 pytest==8.3.3
+    # via
+    #   -r requirements.in
+    #   pytest-cov
+pytest-cov==5.0.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -311,7 +319,9 @@ referencing==0.35.1
     #   jsonschema-specifications
     #   jupyter-events
 requests==2.32.3
-    # via jupyterlab-server
+    # via
+    #   jupyterlab-server
+    #   shedding-hub
 rfc3339-validator==0.1.4
     # via
     #   jsonschema

--- a/shedding_hub/__init__.py
+++ b/shedding_hub/__init__.py
@@ -1,5 +1,6 @@
-from .util import normalize_str
+from .util import load_dataset, normalize_str
 
 __all__ = [
+    "load_dataset",
     "normalize_str",
 ]

--- a/shedding_hub/util.py
+++ b/shedding_hub/util.py
@@ -1,5 +1,9 @@
+import pathlib
 import re
+import requests
 import textwrap
+from typing import Optional
+import yaml
 
 
 def normalize_str(
@@ -21,3 +25,64 @@ def normalize_str(
     if strip:
         value = value.strip()
     return value
+
+
+def load_dataset(
+    dataset: str,
+    *,
+    repo: str = "shedding-hub/shedding-hub",
+    ref: Optional[str] = None,
+    pr: Optional[int] = None,
+    local: Optional[str] = None,
+) -> dict:
+    """
+    Load a dataset from GitHub or a local directory.
+
+    Args:
+        dataset: Dataset identifier, e.g., :code:`woelfel2020virological`.
+        repo: GitHub repository to load data from.
+        ref: Git reference to load. Defaults to the most recent data on the :code:`main`
+            branch of https://github.com/shedding-hub/shedding-hub and is automatically
+            fetched if a :code:`pr` number is specified.
+        pr: Pull request to fetch data from.
+        local: Local directory to load data from.
+
+    Returns:
+        Loaded dataset.
+    """
+    # Check that at most one of `ref`, `pr`, and `local` is given.
+    specified = {"ref": ref, "pr": pr, "local": local}
+    n_specified = sum(1 if x else 0 for x in specified.values())
+    if n_specified > 1:
+        raise ValueError(
+            f"At most one of `ref`, `pr`, or `local` may be specified; got {specified}."
+        )
+
+    # If we have a local file, just read it.
+    if local:
+        path = (pathlib.Path(local) / dataset / dataset).with_suffix(".yaml")
+        with path.open() as fp:
+            return yaml.safe_load(fp)
+
+    # If a PR is specified, resolve it so we can get the relevant file.
+    if pr:
+        response = requests.get(f"https://api.github.com/repos/{repo}/pulls/{pr}")
+        response.raise_for_status()
+        response = response.json()
+        repo = response["head"]["repo"]["full_name"]
+        # Get the sha rather than just the ref because the branch may have been deleted,
+        # but the commit will exist.
+        ref = response["head"]["sha"]
+
+    # Download the contents and parse the file.
+    ref = ref or "main"
+    response = requests.get(
+        f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}/{dataset}.yaml"
+    )
+    # Backwards compatibility before change of folder structure.
+    if response.status_code == 404:
+        response = requests.get(
+            f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}.yaml"
+        )
+    response.raise_for_status()
+    return yaml.safe_load(response.text)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,8 @@
+import hashlib
+import io
 import pytest
 from shedding_hub import util
+import yaml
 
 
 @pytest.mark.parametrize(
@@ -18,3 +21,43 @@ from shedding_hub import util
 )
 def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
     assert util.normalize_str(value, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_sha1",
+    [
+        # This fetches the *current* dataset which may change and hence need adjustment
+        # of the hash. However, this dataset is relatively stable and is unlikely to
+        # need updates.
+        (
+            {"dataset": "woelfel2020virological"},
+            "7a76032013b04139ebe5bcaa3dd092e7f64b5081",
+        ),
+        # An old version of the Woelfel dataset from a PR before folder restructuring.
+        (
+            {"dataset": "woelfel2020", "pr": 1},
+            "7bf4dabae5ba95b06a62f6102fee571b46068786",
+        ),
+        # Invalid because requesting local and pr.
+        (
+            {"dataset": "woelfel2020virological", "local": "data", "pr": 7},
+            ValueError,
+        ),
+        # Load from local directory.
+        (
+            {"dataset": "woelfel2020virological", "local": "data"},
+            "7a76032013b04139ebe5bcaa3dd092e7f64b5081",
+        ),
+    ],
+)
+def test_load(kwargs: dict, expected_sha1: str):
+    if isinstance(expected_sha1, str):
+        data = util.load_dataset(**kwargs)
+        assert "title" in data
+        stream = io.StringIO()
+        yaml.safe_dump(data, stream)
+        actual_sha1 = hashlib.sha1(stream.getvalue().encode()).hexdigest()
+        assert actual_sha1 == expected_sha1
+    else:
+        with pytest.raises(expected_sha1):
+            data = util.load_dataset(**kwargs)


### PR DESCRIPTION
This PR adds a utility function `load_dataset` that can be used to load data in a reproducible fashion by specifying a git ref. E.g., one can specify `load_dataset("woelfel2020virological", ref="[commit hash]")` to load the data as they were at a specific commit. This means analyses will remain reproducible even if the data in this repository evolve.

This PR is also helpful for doing spot-checks of data in pull requests using `load_dataset([dataset name], pr=[pr number])` to load data as they are in the current version of the specified PR.