### PR TITLE
Publish package to PyPI and add data loading example.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,3 +25,5 @@ jobs:
         run: black --check .
       - name: Run tests
         run: pytest -v --cov=shedding_hub --cov-report=term-missing
+      - name: Run doctests
+        run: python -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE README.md

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.11"
           cache: pip
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -27,3 +27,7 @@ jobs:
         run: pytest -v --cov=shedding_hub --cov-report=term-missing
       - name: Run doctests
         run: python -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE README.md
+      - name: Build package
+        run: python -m build
+      - name: Validate package
+        run: twine check dist/*.tar.gz dist/*.whl

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -1,4 +1,4 @@
-name: Deploy GitHub Pages
+name: GitHub Pages
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy-pages:
+    name: Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,30 @@
+name: PyPI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Build package
+        run: python -m build
+      - name: Validate package
+        run: twine check dist/*.tar.gz dist/*.whl
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/summarize.yaml
+++ b/.github/workflows/summarize.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.11"
           cache: pip
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ The Shedding Hub collates data and statistical models for biomarker shedding (su
 
 Datasets are extracted from appendices, figures, and supplementary materials of peer-reviewed studies. Each dataset is stored as a [`.yaml`](https://en.wikipedia.org/wiki/YAML) file and validated against our [data schema](data/.schema.yaml) to verify its integrity.
 
+## 📊 Getting the Data
+
+You can obtain the data by [downloading it from GitHub](https://github.com/shedding-hub/shedding-hub/tree/main/data). We also provide a [convenient Python package](http://pypi.org/project/shedding-hub/) so you can download the most recent data directly in your code or obtain a specific version of the data for reproducible analysis. Install the package by running `pip install shedding-hub` from the command line. The example below downloads the [data from Wölfel et al. (2020)](https://shedding-hub.github.io/datasets/woelfel2020virological.html) as of the commit [`259ca0d`](https://github.com/shedding-hub/shedding-hub/commit/259ca0d).
+
+```python
+>>> import shedding_hub as sh
+
+>>> sh.load_dataset('woelfel2020virological', ref='259ca0d')
+{'title': 'Virological assessment of hospitalized patients with COVID-2019',
+ 'doi': '10.1038/s41586-020-2196-x',
+ ...}
+
+```
+
 ## 🤝 Contributing
 
 Thank you for contributing your data to the Shedding Hub and supporting wastewater-based epidemiology! If you hit a bump along the road, [create a new issue](https://github.com/shedding-hub/shedding-hub/issues/new) and we'll sort it out together.

--- a/requirements.in
+++ b/requirements.in
@@ -10,3 +10,4 @@ pyaml
 pymupdf
 pytest
 pytest-cov
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,8 @@ attrs==24.2.0
     #   referencing
 babel==2.16.0
     # via jupyterlab-server
+backports-tarfile==1.2.0
+    # via jaraco-context
 beautifulsoup4==4.12.3
     # via nbconvert
 black==24.8.0
@@ -65,6 +67,8 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
+docutils==0.21.2
+    # via readme-renderer
 executing==2.1.0
     # via stack-data
 fastjsonschema==2.20.0
@@ -85,6 +89,10 @@ idna==3.8
     #   httpx
     #   jsonschema
     #   requests
+importlib-metadata==8.5.0
+    # via
+    #   keyring
+    #   twine
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
@@ -101,6 +109,12 @@ ipywidgets==8.1.5
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
+jaraco-classes==3.4.0
+    # via keyring
+jaraco-context==6.0.1
+    # via keyring
+jaraco-functools==4.1.0
+    # via keyring
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
@@ -168,12 +182,15 @@ jupyterlab-widgets==3.0.13
     # via ipywidgets
 jupytext==1.16.4
     # via -r requirements.in
+keyring==25.4.1
+    # via twine
 kiwisolver==1.4.7
     # via matplotlib
 markdown-it-py==3.0.0
     # via
     #   jupytext
     #   mdit-py-plugins
+    #   rich
 markupsafe==2.1.5
     # via
     #   jinja2
@@ -190,6 +207,10 @@ mdurl==0.1.2
     # via markdown-it-py
 mistune==3.0.2
     # via nbconvert
+more-itertools==10.5.0
+    # via
+    #   jaraco-classes
+    #   jaraco-functools
 mypy-extensions==1.0.0
     # via black
 nbclient==0.10.0
@@ -206,6 +227,8 @@ nbformat==5.10.4
     #   nbconvert
 nest-asyncio==1.6.0
     # via ipykernel
+nh3==0.2.18
+    # via readme-renderer
 notebook==7.2.2
     # via jupyter
 notebook-shim==0.2.4
@@ -245,6 +268,8 @@ pillow==10.4.0
     # via matplotlib
 pip-tools==7.4.1
     # via -r requirements.in
+pkginfo==1.10.0
+    # via twine
 platformdirs==4.3.2
     # via
     #   black
@@ -276,6 +301,8 @@ pygments==2.18.0
     #   ipython
     #   jupyter-console
     #   nbconvert
+    #   readme-renderer
+    #   rich
 pymupdf==1.24.10
     # via -r requirements.in
 pymupdfb==1.24.10
@@ -313,6 +340,8 @@ pyzmq==26.2.0
     #   jupyter-client
     #   jupyter-console
     #   jupyter-server
+readme-renderer==44.0
+    # via twine
 referencing==0.35.1
     # via
     #   jsonschema
@@ -321,15 +350,23 @@ referencing==0.35.1
 requests==2.32.3
     # via
     #   jupyterlab-server
+    #   requests-toolbelt
     #   shedding-hub
+    #   twine
+requests-toolbelt==1.0.0
+    # via twine
 rfc3339-validator==0.1.4
     # via
     #   jsonschema
     #   jupyter-events
+rfc3986==2.0.0
+    # via twine
 rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
+rich==13.8.1
+    # via twine
 rpds-py==0.20.0
     # via
     #   jsonschema
@@ -380,6 +417,8 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
+twine==5.1.1
+    # via -r requirements.in
 types-python-dateutil==2.9.0.20240906
     # via arrow
 typing-extensions==4.12.2
@@ -389,7 +428,9 @@ tzdata==2024.1
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.2.2
-    # via requests
+    # via
+    #   requests
+    #   twine
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==24.8.0
@@ -404,6 +445,8 @@ wheel==0.44.0
     # via pip-tools
 widgetsnbextension==4.0.13
     # via ipywidgets
+zipp==3.20.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -38,6 +38,11 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
             {"dataset": "woelfel2020", "pr": 1},
             "7bf4dabae5ba95b06a62f6102fee571b46068786",
         ),
+        # The same old version of the Woelfel dataset using a commit reference.
+        (
+            {"dataset": "woelfel2020", "ref": "534c30a"},
+            "7bf4dabae5ba95b06a62f6102fee571b46068786",
+        ),
         # Invalid because requesting local and pr.
         (
             {"dataset": "woelfel2020virological", "local": "data", "pr": 7},


### PR DESCRIPTION
This PR published the package to PyPI so users can install it by running `pip install shedding-hub`. I've also added an example to the README. If we can get this merged before next week, it could be nice to include the data loading example in the symposium slides to show people how easy it is to get the data.

Here's the example.

```python
>>> import shedding_hub as sh

>>> sh.load_dataset('woelfel2020virological', ref='259ca0d')
{'title': 'Virological assessment of hospitalized patients with COVID-2019',
 'doi': '10.1038/s41586-020-2196-x',
 ...}

```

**Edit**: This will fail the first time we run it on `main` because we need to set up permissions. But that's expected.