### PR TITLE
Create module to summarize and visualize shedding duration at individual study level and across multiple studies

### DIFF
--- a/.github/workflows/summarize.py
+++ b/.github/workflows/summarize.py
@@ -65,7 +65,7 @@ def __main__(argv=None) -> None:
         }
         lines.extend(
             [
-                f"🔄 Summary for changed file `{filename}`:",
+                f"Summary for changed file `{filename}`:",
                 "",
                 "```",
                 pd.DataFrame(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ description = "Data and statistical models for biomarker shedding."
 dependencies = [
     "pyaml",
     "requests",
+    "pandas",
+    "matplotlib"
 ]
 
 [tool.setuptools.packages]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,13 +6,13 @@
 #
 -e file:.
     # via -r requirements.in
-anyio==4.8.0
+anyio==4.9.0
     # via
     #   httpx
     #   jupyter-server
 appnope==0.1.4
     # via ipykernel
-argon2-cffi==23.1.0
+argon2-cffi==25.1.0
     # via jupyter-server
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
@@ -20,9 +20,9 @@ arrow==1.3.0
     # via isoduration
 asttokens==3.0.0
     # via stack-data
-async-lru==2.0.4
+async-lru==2.0.5
     # via jupyterlab
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
@@ -30,7 +30,7 @@ babel==2.17.0
     # via jupyterlab-server
 backports-tarfile==1.2.0
     # via jaraco-context
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via nbconvert
 black==25.1.0
     # via -r requirements.in
@@ -38,16 +38,16 @@ bleach[css]==6.2.0
     # via nbconvert
 build==1.2.2.post1
     # via pip-tools
-certifi==2025.1.31
+certifi==2025.7.14
     # via
     #   httpcore
     #   httpx
     #   requests
 cffi==1.17.1
     # via argon2-cffi-bindings
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.1
     # via
     #   black
     #   pip-tools
@@ -55,13 +55,13 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.3.1
+contourpy==1.3.2
     # via matplotlib
-coverage[toml]==7.6.12
+coverage[toml]==7.9.2
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
-debugpy==1.8.12
+debugpy==1.8.14
     # via ipykernel
 decorator==5.2.1
     # via ipython
@@ -75,13 +75,13 @@ executing==2.2.0
     # via stack-data
 fastjsonschema==2.21.1
     # via nbformat
-fonttools==4.56.0
+fonttools==4.58.5
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
-h11==0.14.0
+h11==0.16.0
     # via httpcore
-httpcore==1.0.7
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via jupyterlab
@@ -93,21 +93,23 @@ idna==3.10
     #   httpx
     #   jsonschema
     #   requests
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via keyring
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 ipykernel==6.29.5
     # via
     #   jupyter
     #   jupyter-console
     #   jupyterlab
-ipython==8.32.0
+ipython==9.4.0
     # via
     #   ipykernel
     #   ipywidgets
     #   jupyter-console
-ipywidgets==8.1.5
+ipython-pygments-lexers==1.1.1
+    # via ipython
+ipywidgets==8.1.7
     # via jupyter
 isoduration==20.11.0
     # via jsonschema
@@ -115,29 +117,29 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.2.1
     # via keyring
 jedi==0.19.2
     # via ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server
     #   nbconvert
-joblib==1.4.2
+joblib==1.5.1
     # via scikit-learn
-json5==0.10.0
+json5==0.12.0
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format-nongpl]==4.23.0
+jsonschema[format-nongpl]==4.24.0
     # via
     #   -r requirements.in
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
 jupyter==1.1.1
     # via -r requirements.in
@@ -149,7 +151,7 @@ jupyter-client==8.6.3
     #   nbclient
 jupyter-console==6.6.3
     # via jupyter
-jupyter-core==5.7.2
+jupyter-core==5.8.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -163,7 +165,7 @@ jupyter-events==0.12.0
     # via jupyter-server
 jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.15.0
+jupyter-server==2.16.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -172,7 +174,7 @@ jupyter-server==2.15.0
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.3.5
+jupyterlab==4.4.4
     # via
     #   jupyter
     #   notebook
@@ -182,9 +184,9 @@ jupyterlab-server==2.27.3
     # via
     #   jupyterlab
     #   notebook
-jupyterlab-widgets==3.0.13
+jupyterlab-widgets==3.0.15
     # via ipywidgets
-jupytext==1.16.7
+jupytext==1.17.2
     # via -r requirements.in
 keyring==25.6.0
     # via twine
@@ -199,8 +201,10 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   nbconvert
-matplotlib==3.10.0
-    # via -r requirements.in
+matplotlib==3.10.3
+    # via
+    #   -r requirements.in
+    #   shedding-hub
 matplotlib-inline==0.1.7
     # via
     #   ipykernel
@@ -209,13 +213,13 @@ mdit-py-plugins==0.4.2
     # via jupytext
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.1.2
+mistune==3.1.3
     # via nbconvert
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 nbclient==0.10.2
     # via nbconvert
@@ -231,15 +235,15 @@ nbformat==5.10.4
     #   nbconvert
 nest-asyncio==1.6.0
     # via ipykernel
-nh3==0.2.20
+nh3==0.2.21
     # via readme-renderer
-notebook==7.3.2
+notebook==7.4.4
     # via jupyter
 notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==2.2.3
+numpy==2.3.1
     # via
     #   contourpy
     #   matplotlib
@@ -250,7 +254,7 @@ openpyxl==3.1.5
     # via -r requirements.in
 overrides==7.7.0
     # via jupyter-server
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   build
@@ -264,8 +268,10 @@ packaging==24.2
     #   nbconvert
     #   pytest
     #   twine
-pandas==2.2.3
-    # via -r requirements.in
+pandas==2.3.1
+    # via
+    #   -r requirements.in
+    #   shedding-hub
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -274,19 +280,21 @@ pathspec==0.12.1
     # via black
 pexpect==4.9.0
     # via ipython
-pillow==11.1.0
+pillow==11.3.0
     # via matplotlib
 pip-tools==7.4.1
     # via -r requirements.in
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   black
     #   jupyter-core
-pluggy==1.5.0
-    # via pytest
-prometheus-client==0.21.1
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+prometheus-client==0.22.1
     # via jupyter-server
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   ipython
     #   jupyter-console
@@ -298,32 +306,34 @@ ptyprocess==0.7.0
     #   terminado
 pure-eval==0.2.3
     # via stack-data
-pyaml==25.1.0
+pyaml==25.7.0
     # via
     #   -r requirements.in
     #   shedding-hub
 pycparser==2.22
     # via cffi
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   ipython
+    #   ipython-pygments-lexers
     #   jupyter-console
     #   nbconvert
+    #   pytest
     #   readme-renderer
     #   rich
-pymupdf==1.25.3
+pymupdf==1.26.3
     # via -r requirements.in
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via matplotlib
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.4
+pytest==8.4.1
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
@@ -331,16 +341,16 @@ python-dateutil==2.9.0.post0
     #   jupyter-client
     #   matplotlib
     #   pandas
-python-json-logger==3.2.1
+python-json-logger==3.3.0
     # via jupyter-events
-pytz==2025.1
+pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via
     #   jupyter-events
     #   jupytext
     #   pyaml
-pyzmq==26.2.1
+pyzmq==27.0.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -353,7 +363,7 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-requests==2.32.3
+requests==2.32.4
     # via
     #   id
     #   jupyterlab-server
@@ -372,15 +382,15 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rich==13.9.4
+rich==14.0.0
     # via twine
-rpds-py==0.23.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-scikit-learn==1.6.1
+scikit-learn==1.7.0
     # via -r requirements.in
-scipy==1.15.2
+scipy==1.16.0
     # via scikit-learn
 send2trash==1.8.3
     # via jupyter-server
@@ -390,7 +400,7 @@ six==1.17.0
     #   rfc3339-validator
 sniffio==1.3.1
     # via anyio
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 stack-data==0.6.3
     # via ipython
@@ -398,11 +408,11 @@ terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
-threadpoolctl==3.5.0
+threadpoolctl==3.6.0
     # via scikit-learn
 tinycss2==1.4.0
     # via bleach
-tornado==6.4.2
+tornado==6.5.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -428,19 +438,19 @@ traitlets==5.14.3
     #   nbformat
 twine==6.1.0
     # via -r requirements.in
-types-python-dateutil==2.9.0.20241206
+types-python-dateutil==2.9.0.20250708
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.14.1
     # via
     #   anyio
     #   beautifulsoup4
     #   ipython
     #   referencing
-tzdata==2025.1
+tzdata==2025.2
     # via pandas
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.3.0
+urllib3==2.5.0
     # via
     #   requests
     #   twine
@@ -456,9 +466,9 @@ websocket-client==1.8.0
     # via jupyter-server
 wheel==0.45.1
     # via pip-tools
-widgetsnbextension==4.0.13
+widgetsnbextension==4.0.14
     # via ipywidgets
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/shedding_hub/__init__.py
+++ b/shedding_hub/__init__.py
@@ -1,8 +1,18 @@
 from .util import folded_str, literal_str, load_dataset, normalize_str
+from .shedding_duration import (
+    calc_shedding_duration,
+    calc_shedding_durations,
+    plot_shedding_duration,
+    plot_shedding_durations,
+)
 
 __all__ = [
     "folded_str",
     "literal_str",
     "load_dataset",
     "normalize_str",
+    "calc_shedding_duration",
+    "calc_shedding_durations",
+    "plot_shedding_duration",
+    "plot_shedding_durations",
 ]

--- a/shedding_hub/shedding_duration.py
+++ b/shedding_hub/shedding_duration.py
@@ -121,7 +121,9 @@ def calc_shedding_duration(
     )
 
     # calculate individual level shedding duration
-    df_shedding_duration["shedding_duration"] = df_shedding_duration["last_detect"] - df_shedding_duration["first_detect"] + 1
+    df_shedding_duration["shedding_duration"] = (
+        df_shedding_duration["last_detect"] - df_shedding_duration["first_detect"] + 1
+    )
 
     if plotting:
         plt_shedding = plot_shedding_duration(

--- a/shedding_hub/shedding_duration.py
+++ b/shedding_hub/shedding_duration.py
@@ -1,0 +1,350 @@
+import shedding_hub as sh
+import pandas as pd
+from typing import Optional
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+from matplotlib.lines import Line2D
+import glob
+from pathlib import Path
+
+
+def calc_shedding_duration(
+    df_ID: str,
+    *,
+    plotting: bool = False,
+    ref: Optional[str] = None,
+    pr: Optional[int] = None,
+    local: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Calcualte summary statistics for the shedding duration using a loaded dataset by the `load_dataset` function.
+
+    Args:
+        df_ID: Dataset identifier, e.g., :code:`woelfel2020virological`.
+        plotting: Create a plot for individual level of shedding duration by specimen type.
+        ref: Git reference to load. Defaults to the most recent data on the :code:`main`
+            branch of https://github.com/shedding-hub/shedding-hub and is automatically
+            fetched if a :code:`pr` number is specified.
+        pr: Pull request to fetch data from.
+        local: Local directory to load data from.
+
+    Returns:
+        Summary table of shedding duration (min, max, mean) by biomarker and specimen.
+    """
+    # load the dataset;
+    df = sh.load_dataset(dataset=df_ID, ref=ref, pr=pr, local=local)
+    # initialize a pandas dataframe
+    df_shedding_duration = pd.DataFrame(
+        columns=[
+            "study_ID",
+            "participant_ID",  # "age","sex",
+            "analyte",
+            "n_sample",
+            "first_sample",
+            "last_sample",
+            "first_detect",
+            "last_detect",
+        ]
+    )
+    df_analyte = pd.DataFrame(
+        columns=["analyte", "specimen", "biomarker", "reference_event"]
+    )
+
+    # extract analyte data from the standardized shedding data loaded
+    for key in df["analytes"]:
+        row_new = {
+            "analyte": key,
+            "specimen": df["analytes"][key]["specimen"],
+            "biomarker": df["analytes"][key]["biomarker"],
+            "reference_event": df["analytes"][key]["reference_event"],
+        }
+        df_analyte.loc[len(df_analyte)] = row_new
+
+    # extract participant and measurement data from the standardized shedding data loaded
+    participant_counter = 0
+    for item in df["participants"]:
+        participant_counter += 1
+        participant_ID = participant_counter
+        # participant_age = item["attributes"]["age"]
+        # participant_sex = item["attributes"]["sex"]
+        for name, group in pd.DataFrame.from_dict(item["measurements"]).groupby(
+            "analyte"
+        ):
+            row_new = {
+                "study_ID": df_ID,
+                "participant_ID": participant_ID,
+                # "age" : participant_age,
+                # "sex" : participant_sex,
+                "analyte": name,
+                "n_sample": group[group["value"].notna()]["time"].size,
+                "first_sample": group[group["value"].notna()]["time"].min(),
+                "last_sample": group[group["value"].notna()]["time"].max(),
+                "first_detect": group[
+                    (group["value"] != "negative") & (group["value"].notna())
+                ]["time"].min(),
+                "last_detect": group[
+                    (group["value"] != "negative") & (group["value"].notna())
+                ]["time"].max(),
+            }
+            df_shedding_duration.loc[len(df_shedding_duration)] = row_new
+
+    # merge analyte information and drop analyte column
+    df_shedding_duration = df_shedding_duration.merge(
+        df_analyte, how="left", on="analyte"
+    ).drop(columns=["analyte"])
+    # calculate individual level shedding duration
+    df_shedding_duration["first_sample"] = pd.to_numeric(
+        df_shedding_duration["first_sample"], errors="coerce"
+    )
+    df_shedding_duration["last_sample"] = pd.to_numeric(
+        df_shedding_duration["last_sample"], errors="coerce"
+    )
+    df_shedding_duration["first_detect"] = pd.to_numeric(
+        df_shedding_duration["first_detect"], errors="coerce"
+    )
+    df_shedding_duration["last_detect"] = pd.to_numeric(
+        df_shedding_duration["last_detect"], errors="coerce"
+    )
+    df_shedding_duration["shedding_duration"] = (
+        df_shedding_duration["last_detect"] - df_shedding_duration["first_detect"] + 1
+    )
+
+    if plotting == True:
+        plt_shedding = plot_shedding_duration(df_shedding_duration, df_ID=df_ID)
+        plt_shedding.show()
+
+    df_return = (
+        df_shedding_duration.groupby(
+            ["study_ID", "biomarker", "specimen", "reference_event"]
+        )
+        .agg(
+            shedding_duration_min=("shedding_duration", "min"),
+            shedding_duration_max=("shedding_duration", "max"),
+            shedding_duration_mean=("shedding_duration", "mean"),
+            n_sample=("n_sample", "sum"),
+            n_participant=("participant_ID", "nunique"),
+        )
+        .reset_index()
+    )
+
+    return df_return
+
+
+def plot_shedding_duration(df_shedding_duration: pd.DataFrame, df_ID: str):
+    """
+    Plot shedding duration for each individuals by specimen type.
+
+    Args:
+        df_shedding_duration: Shedding duration dataset extracted from the loaded dataset.
+        df_ID: Dataset identifier, e.g., :code:`woelfel2020virological`.
+
+    Returns:
+        The plot of shedding duration.
+    """
+    # Plot range bars
+    plt.figure(figsize=(8, 6))
+
+    # Sort dataset by specimen group
+    df_shedding_duration_sorted = df_shedding_duration.sort_values("specimen")
+
+    specimen_counter = 0
+    participant_counter = 0
+    color_map = list(mcolors.TABLEAU_COLORS.values())
+    specimen_colors = {}
+
+    for name, group in df_shedding_duration_sorted.groupby("specimen"):
+        color = color_map[specimen_counter % len(color_map)]
+        specimen_colors[name] = color
+        for __, row in group.iterrows():
+            (line_sampl,) = plt.plot(
+                [row["first_sample"], row["last_sample"]],
+                [participant_counter, participant_counter],
+                linestyle="--",
+                marker="o",
+                color=color,
+            )
+            (line_shed,) = plt.plot(
+                [row["first_detect"], row["last_detect"]],
+                [participant_counter, participant_counter],
+                linestyle="-",
+                marker="o",
+                color=color,
+            )
+            participant_counter += 1
+        specimen_counter += 1
+
+    # Legend for specimen (color)
+    specimen_legend = [
+        Line2D([0], [0], color=color, lw=2, label=specimen)
+        for specimen, color in specimen_colors.items()
+    ]
+
+    # Legend for line style (duration type)
+    linestyle_legend = [
+        Line2D(
+            [0], [0], color="black", lw=2, linestyle="--", label="Sampling Duration"
+        ),
+        Line2D([0], [0], color="black", lw=2, linestyle="-", label="Shedding Duration"),
+    ]
+
+    # Add both legends
+    plt.legend(
+        handles=specimen_legend + linestyle_legend, title="Legend", loc="upper right"
+    )
+
+    plt.yticks([])
+    plt.xlabel(f"Days after {df_shedding_duration["reference_event"][0]}")
+    plt.title(f'Individual Shedding Duration for the Study "{df_ID}"')
+    plt.grid(True, axis="x")
+    plt.tight_layout()
+    return plt
+
+
+def calc_shedding_durations(
+    df_IDs: list[str], *, plotting: bool = False, biomarker: str = "SARS-CoV-2"
+) -> pd.DataFrame:
+    """
+    Calcualte summary statistics for the shedding duration using a loaded dataset by the `load_dataset` function.
+
+    Args:
+        df_IDs : A list of dataset identifiers.
+        plotting: Create a plot for study level of shedding duration by specimen type.
+        biomarker: Filter the data for plotting with a specific biomarker (e.g., "SARS-CoV-2").
+
+    Returns:
+        Summary table of shedding duration (min, max, mean, n_sample, n_participant) by study, biomarker, and specimen.
+    """
+    # Initialize an empty DataFrame with columns
+    df_shedding_durations = pd.DataFrame(
+        columns=[
+            "study_ID",
+            "biomarker",
+            "specimen",
+            "reference_event",
+            "shedding_duration_min",
+            "shedding_duration_max",
+            "shedding_duration_mean",
+            "n_sample",
+            "n_participant",
+        ]
+    )
+
+    # Loop to append data
+    for (
+        filename
+    ) in df_IDs:  # [Path(file).stem for file in Path("data").glob("*/*.yaml")]:
+        print(f"Load the data: {filename}")
+        try:
+            if len(df_shedding_durations) == 0:
+                df_shedding_durations = calc_shedding_duration(
+                    df_ID=filename, plotting=False
+                )
+
+            elif len(calc_shedding_duration(df_ID=filename, plotting=False)) == 0:
+                pass
+            else:
+                df_shedding_durations = pd.concat(
+                    [
+                        df_shedding_durations,
+                        calc_shedding_duration(df_ID=filename, plotting=False),
+                    ],
+                    ignore_index=True,
+                )
+        except:
+            print(f"Cannot load the data {filename}!!!")
+    if plotting == True:
+        plt_sheddings = plot_shedding_durations(
+            df_shedding_durations, biomarker=biomarker
+        )
+        plt_sheddings.show()
+    return df_shedding_durations
+
+
+def plot_shedding_durations(
+    df_shedding_durations: pd.DataFrame, biomarker: str = "SARS-CoV-2"
+):
+    """
+    Plot shedding duration by study and specimen type.
+
+    Args:
+        df_shedding_durations: Shedding duration dataset extracted from the multiple loaded datasets.
+        biomarker: Filter the data for plotting with a specific biomarker (e.g., "SARS-CoV-2").
+
+    Returns:
+        The plot of shedding duration by study and sample type.
+    """
+    # Plot range bars
+    plt.figure(figsize=(10, 8))
+
+    # filter the dataset by biomaker
+    df_shedding_durations_filtered = df_shedding_durations.loc[
+        (
+            (df_shedding_durations["biomarker"] == biomarker)
+            & (~df_shedding_durations["shedding_duration_mean"].isnull())
+        )
+    ]
+
+    # Sort dataset by specimen group
+    df_shedding_durations_sorted = df_shedding_durations_filtered.sort_values(
+        "specimen"
+    )
+
+    specimen_counter = 0
+    study_counter = 0
+    color_map = list(mcolors.TABLEAU_COLORS.values())
+
+    # Store a handle for each specimen group for the legend
+    legend_handles = []
+
+    for name, group in df_shedding_durations_sorted.groupby("specimen"):
+        color = color_map[specimen_counter % len(color_map)]
+        for __, row in group.iterrows():
+            x_vals = [
+                row["shedding_duration_min"],
+                row["shedding_duration_mean"],
+                row["shedding_duration_max"],
+            ]
+            y_vals = [study_counter] * 3
+            # Plot the connecting line without markers
+            (line,) = plt.plot(x_vals, y_vals, color=color, linestyle="-")
+            # Add custom markers
+            plt.plot(
+                row["shedding_duration_min"],
+                study_counter,
+                marker="|",
+                color=color,
+                markersize=10,
+            )
+            plt.plot(
+                row["shedding_duration_max"],
+                study_counter,
+                marker="|",
+                color=color,
+                markersize=10,
+            )
+            plt.plot(
+                row["shedding_duration_mean"], study_counter, marker="o", color=color
+            )
+            study_counter += 1
+        legend_handles.append((line, name))
+        specimen_counter += 1
+
+    # Add legend
+    handles, labels = zip(*legend_handles)
+    plt.legend(handles, labels, title="Specimen", loc="upper right")
+
+    plt.yticks(
+        ticks=range(len(df_shedding_durations_sorted["study_ID"])),
+        labels=[
+            a + " (N=" + str(b) + ")"
+            for a, b in zip(
+                df_shedding_durations_sorted["study_ID"].values,
+                df_shedding_durations_sorted["n_participant"],
+            )
+        ],
+    )
+    plt.xlabel("Number of Days")
+    plt.title(f"Shedding Duration Plot for {biomarker}")
+    plt.grid(True, axis="x")
+    plt.tight_layout()
+    return plt

--- a/shedding_hub/shedding_duration.py
+++ b/shedding_hub/shedding_duration.py
@@ -193,7 +193,7 @@ def plot_shedding_duration(df_shedding_duration: pd.DataFrame, df_ID: str):
     )
 
     plt.yticks([])
-    plt.xlabel(f"Days after {df_shedding_duration["reference_event"][0]}")
+    plt.xlabel(f"Days after {df_shedding_duration['reference_event'][0]}")
     plt.title(f'Individual Shedding Duration for the Study "{df_ID}"')
     plt.grid(True, axis="x")
     plt.tight_layout()

--- a/shedding_hub/shedding_duration.py
+++ b/shedding_hub/shedding_duration.py
@@ -77,13 +77,21 @@ def calc_shedding_duration(
                 # "sex" : participant_sex,
                 "analyte": name,
                 "n_sample": group[group["value"].notna()]["time"].size,
-                "first_sample": group[group["value"].notna()]["time"].min(),
-                "last_sample": group[group["value"].notna()]["time"].max(),
+                "first_sample": group[
+                    (group["value"].notna()) & (group["time"] != "unknown")
+                ]["time"].min(),
+                "last_sample": group[
+                    (group["value"].notna()) & (group["time"] != "unknown")
+                ]["time"].max(),
                 "first_detect": group[
-                    (group["value"] != "negative") & (group["value"].notna())
+                    (group["value"] != "negative")
+                    & (group["value"].notna())
+                    & (group["time"] != "unknown")
                 ]["time"].min(),
                 "last_detect": group[
-                    (group["value"] != "negative") & (group["value"].notna())
+                    (group["value"] != "negative")
+                    & (group["value"].notna())
+                    & (group["time"] != "unknown")
                 ]["time"].max(),
             }
             df_shedding_duration.loc[len(df_shedding_duration)] = row_new
@@ -92,6 +100,10 @@ def calc_shedding_duration(
     df_shedding_duration = df_shedding_duration.merge(
         df_analyte, how="left", on="analyte"
     ).drop(columns=["analyte"])
+    # concatenate list of specimen types to string;
+    df_shedding_duration["specimen"] = df_shedding_duration["specimen"].apply(
+        lambda x: ", ".join(map(str, x)) if isinstance(x, list) else str(x)
+    )
     # calculate individual level shedding duration
     df_shedding_duration["first_sample"] = pd.to_numeric(
         df_shedding_duration["first_sample"], errors="coerce"

--- a/shedding_hub/shedding_duration.py
+++ b/shedding_hub/shedding_duration.py
@@ -7,6 +7,14 @@ from matplotlib.lines import Line2D
 import traceback
 import logging
 
+try:
+    from IPython.display import display
+except ImportError:
+    # Fallback for non-IPython environments (like unit tests)
+    def display(fig):
+        pass  # Do nothing when not in IPython
+
+
 # Constants
 DEFAULT_BIOMARKER = "SARS-CoV-2"
 DEFAULT_FIGURE_SIZE = (8, 6)
@@ -167,7 +175,6 @@ def plot_shedding_duration(
 
     Args:
         df_shedding_duration: Shedding duration dataset extracted from the loaded dataset.
-        dataset_id: Dataset identifier, e.g., :code:`woelfel2020virological`.
         max_nparticipant: Maximum number of participants to show per specimen type.
             If exceeded, participants are randomly sampled.
         random_seed: Random seed for participant sampling when max_nparticipant is exceeded.

--- a/shedding_hub/util.py
+++ b/shedding_hub/util.py
@@ -63,7 +63,7 @@ def load_dataset(
         path = (pathlib.Path(local) / dataset / dataset).with_suffix(".yaml")
         with path.open() as fp:
             data = yaml.safe_load(fp)
-        data["study_ID"] = dataset
+        data["dataset_id"] = dataset
         return data
 
     # If a PR is specified, resolve it so we can get the relevant file.

--- a/shedding_hub/util.py
+++ b/shedding_hub/util.py
@@ -28,7 +28,7 @@ def normalize_str(
 
 
 def load_dataset(
-    dataset_ID: str,
+    dataset: str,
     *,
     repo: str = "shedding-hub/shedding-hub",
     ref: Optional[str] = None,
@@ -39,7 +39,7 @@ def load_dataset(
     Load a dataset from GitHub or a local directory.
 
     Args:
-        dataset_ID: Dataset identifier, e.g., :code:`woelfel2020virological`.
+        dataset: Dataset identifier, e.g., :code:`woelfel2020virological`.
         repo: GitHub repository to load data from.
         ref: Git reference to load. Defaults to the most recent data on the :code:`main`
             branch of https://github.com/shedding-hub/shedding-hub and is automatically
@@ -60,10 +60,10 @@ def load_dataset(
 
     # If we have a local file, just read it.
     if local:
-        path = (pathlib.Path(local) / dataset_ID / dataset_ID).with_suffix(".yaml")
+        path = (pathlib.Path(local) / dataset / dataset).with_suffix(".yaml")
         with path.open() as fp:
             data = yaml.safe_load(fp)
-        data["study_ID"] = dataset_ID
+        data["study_ID"] = dataset
         return data
 
     # If a PR is specified, resolve it so we can get the relevant file.
@@ -79,16 +79,16 @@ def load_dataset(
     # Download the contents and parse the file.
     ref = ref or "main"
     response = requests.get(
-        f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset_ID}/{dataset_ID}.yaml"
+        f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}/{dataset}.yaml"
     )
     # Backwards compatibility before change of folder structure.
     if response.status_code == 404:
         response = requests.get(
-            f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset_ID}.yaml"
+            f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}.yaml"
         )
     response.raise_for_status()
     data = yaml.safe_load(response.text)
-    data["study_ID"] = dataset_ID
+    data["dataset_id"] = dataset
     return data
 
 

--- a/tests/test_shedding_duration.py
+++ b/tests/test_shedding_duration.py
@@ -1,0 +1,134 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+import pandas as pd
+from unittest.mock import patch, MagicMock
+import shedding_hub as sh
+
+
+# Sample minimal datasets for testing
+@pytest.fixture
+def minimal_dataset():
+    return {
+        "dataset_id": "test_dataset",
+        "analytes": {
+            "A": {
+                "specimen": "stool",
+                "biomarker": "SARS-CoV-2",
+                "reference_event": "symptom onset",
+            }
+        },
+        "participants": [
+            {
+                "measurements": [
+                    {"analyte": "A", "value": 1.0, "time": 0},
+                    {"analyte": "A", "value": 2.0, "time": 1},
+                    {"analyte": "A", "value": "negative", "time": 2},
+                ]
+            },
+            {
+                "measurements": [
+                    {"analyte": "A", "value": "negative", "time": 0},
+                    {"analyte": "A", "value": 3.0, "time": 1},
+                ]
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def minimal_dataset_2():
+    return {
+        "dataset_id": "test_dataset_2",
+        "analytes": {
+            "B": {
+                "specimen": "nasal",
+                "biomarker": "SARS-CoV-2",
+                "reference_event": "symptom onset",
+            },
+            "C": {
+                "specimen": "serum",
+                "biomarker": "SARS-CoV-2",
+                "reference_event": "symptom onset",
+            },
+        },
+        "participants": [
+            {
+                "measurements": [
+                    {"analyte": "B", "value": 1.0, "time": 0},
+                    {"analyte": "B", "value": "negative", "time": 5},
+                    {"analyte": "C", "value": 2.0, "time": 1},
+                    {"analyte": "C", "value": 3.0, "time": 3},
+                ]
+            },
+            {
+                "measurements": [
+                    {"analyte": "B", "value": 2.0, "time": 1},
+                    {"analyte": "B", "value": 3.0, "time": 3},
+                    {"analyte": "C", "value": "negative", "time": 0},
+                    {"analyte": "C", "value": 1.0, "time": 2},
+                ]
+            },
+        ],
+    }
+
+
+def test_calc_shedding_duration_valid(minimal_dataset):
+    df = sh.calc_shedding_duration(minimal_dataset)
+    assert not df.empty
+    assert "shedding_duration_min" in df.columns
+    assert df["dataset_id"].iloc[0] == "test_dataset"
+
+
+def test_calc_shedding_duration_invalid():
+    with pytest.raises(ValueError):
+        sh.calc_shedding_duration({})
+    with pytest.raises(ValueError):
+        sh.calc_shedding_duration({"foo": "bar"})
+
+
+@patch("shedding_hub.shedding_duration.sh.load_dataset")
+def test_calc_shedding_durations_valid(mock_load_dataset, minimal_dataset):
+    mock_load_dataset.return_value = minimal_dataset
+    df = sh.calc_shedding_durations(["test_dataset"])
+    assert not df.empty
+    assert "shedding_duration_mean" in df.columns
+
+
+@patch("shedding_hub.shedding_duration.sh.load_dataset")
+def test_calc_shedding_durations_all_fail(mock_load_dataset):
+    mock_load_dataset.side_effect = Exception("fail")
+    df = sh.calc_shedding_durations(["bad_dataset"])
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_plot_shedding_duration(minimal_dataset):
+    fig = sh.calc_shedding_duration(minimal_dataset, plotting=True)
+    assert fig is not None
+
+
+def test_plot_shedding_duration_empty():
+    with pytest.raises(ValueError):
+        sh.plot_shedding_duration(pd.DataFrame(), dataset_id="test_dataset")
+
+
+@patch("shedding_hub.shedding_duration.sh.load_dataset")
+def test_plot_shedding_durations_with_ids(
+    mock_load_dataset, minimal_dataset, minimal_dataset_2
+):
+    mock_load_dataset.side_effect = [minimal_dataset, minimal_dataset_2]
+    df1 = sh.calc_shedding_duration(minimal_dataset)
+    df2 = sh.calc_shedding_duration(minimal_dataset_2)
+    df = pd.concat([df1, df2], ignore_index=True)
+    fig = sh.plot_shedding_durations(df, biomarker="SARS-CoV-2")
+    import matplotlib.figure
+
+    assert isinstance(fig, matplotlib.figure.Figure)
+
+
+def test_plot_shedding_durations_empty():
+    with pytest.raises(ValueError):
+        sh.plot_shedding_durations(pd.DataFrame(), biomarker="SARS-CoV-2")

--- a/tests/test_shedding_duration.py
+++ b/tests/test_shedding_duration.py
@@ -100,9 +100,8 @@ def test_calc_shedding_durations_valid(mock_load_dataset, minimal_dataset):
 @patch("shedding_hub.shedding_duration.sh.load_dataset")
 def test_calc_shedding_durations_all_fail(mock_load_dataset):
     mock_load_dataset.side_effect = Exception("fail")
-    df = sh.calc_shedding_durations(["bad_dataset"])
-    assert isinstance(df, pd.DataFrame)
-    assert df.empty
+    with pytest.raises(Exception):
+        df = sh.calc_shedding_durations(["bad_dataset"])
 
 
 def test_plot_shedding_duration(minimal_dataset):

--- a/tests/test_shedding_duration.py
+++ b/tests/test_shedding_duration.py
@@ -111,7 +111,7 @@ def test_plot_shedding_duration(minimal_dataset):
 
 def test_plot_shedding_duration_empty():
     with pytest.raises(ValueError):
-        sh.plot_shedding_duration(pd.DataFrame(), dataset_id="test_dataset")
+        sh.plot_shedding_duration(pd.DataFrame())
 
 
 @patch("shedding_hub.shedding_duration.sh.load_dataset")

--- a/tests/test_shedding_duration.py
+++ b/tests/test_shedding_duration.py
@@ -4,7 +4,6 @@ matplotlib.use("Agg")
 
 import pytest
 import pandas as pd
-from unittest.mock import patch, MagicMock
 import shedding_hub as sh
 
 

--- a/tests/test_shedding_duration.py
+++ b/tests/test_shedding_duration.py
@@ -135,11 +135,7 @@ def test_plot_shedding_duration_empty():
         sh.plot_shedding_duration(pd.DataFrame())
 
 
-@patch("shedding_hub.shedding_duration.sh.load_dataset")
-def test_plot_shedding_durations_with_ids(
-    mock_load_dataset, minimal_dataset, minimal_dataset_2
-):
-    mock_load_dataset.side_effect = [minimal_dataset, minimal_dataset_2]
+def test_plot_shedding_durations_with_ids(minimal_dataset, minimal_dataset_2):
     # Get summary data for both datasets
     df1 = sh.calc_shedding_duration(minimal_dataset, output="summary")
     df2 = sh.calc_shedding_duration(minimal_dataset_2, output="summary")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,17 +31,17 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
         # need updates.
         (
             {"dataset": "woelfel2020virological"},
-            "0fae1c755023b347002be6cf1551a2b79b31b19a",
+            "7a7453c9259f1043657f8d19fbfdf2f69aaf5a30",
         ),
         # An old version of the Woelfel dataset from a PR before folder restructuring.
         (
             {"dataset": "woelfel2020", "pr": 1},
-            "89b17f0f1c00c8c50a83ff15c6d28138afc262ca",
+            "dbf4335ebae87445c821a0772178180a596f5615",
         ),
         # The same old version of the Woelfel dataset using a commit reference.
         (
             {"dataset": "woelfel2020", "ref": "534c30a"},
-            "89b17f0f1c00c8c50a83ff15c6d28138afc262ca",
+            "dbf4335ebae87445c821a0772178180a596f5615",
         ),
         # Invalid because requesting local and pr.
         (
@@ -51,7 +51,7 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
         # Load from local directory.
         (
             {"dataset": "woelfel2020virological", "local": "data"},
-            "0fae1c755023b347002be6cf1551a2b79b31b19a",
+            "7a7453c9259f1043657f8d19fbfdf2f69aaf5a30",
         ),
     ],
 )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,27 +30,27 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
         # of the hash. However, this dataset is relatively stable and is unlikely to
         # need updates.
         (
-            {"dataset_ID": "woelfel2020virological"},
+            {"dataset": "woelfel2020virological"},
             "0fae1c755023b347002be6cf1551a2b79b31b19a",
         ),
         # An old version of the Woelfel dataset from a PR before folder restructuring.
         (
-            {"dataset_ID": "woelfel2020", "pr": 1},
+            {"dataset": "woelfel2020", "pr": 1},
             "89b17f0f1c00c8c50a83ff15c6d28138afc262ca",
         ),
         # The same old version of the Woelfel dataset using a commit reference.
         (
-            {"dataset_ID": "woelfel2020", "ref": "534c30a"},
+            {"dataset": "woelfel2020", "ref": "534c30a"},
             "89b17f0f1c00c8c50a83ff15c6d28138afc262ca",
         ),
         # Invalid because requesting local and pr.
         (
-            {"dataset_ID": "woelfel2020virological", "local": "data", "pr": 7},
+            {"dataset": "woelfel2020virological", "local": "data", "pr": 7},
             ValueError,
         ),
         # Load from local directory.
         (
-            {"dataset_ID": "woelfel2020virological", "local": "data"},
+            {"dataset": "woelfel2020virological", "local": "data"},
             "0fae1c755023b347002be6cf1551a2b79b31b19a",
         ),
     ],

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,17 +31,17 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
         # need updates.
         (
             {"dataset_ID": "woelfel2020virological"},
-            "d93f77da4babf4247f7775121adc749337f53f31",
+            "0fae1c755023b347002be6cf1551a2b79b31b19a",
         ),
         # An old version of the Woelfel dataset from a PR before folder restructuring.
         (
             {"dataset_ID": "woelfel2020", "pr": 1},
-            "7bf4dabae5ba95b06a62f6102fee571b46068786",
+            "89b17f0f1c00c8c50a83ff15c6d28138afc262ca",
         ),
         # The same old version of the Woelfel dataset using a commit reference.
         (
             {"dataset_ID": "woelfel2020", "ref": "534c30a"},
-            "7bf4dabae5ba95b06a62f6102fee571b46068786",
+            "89b17f0f1c00c8c50a83ff15c6d28138afc262ca",
         ),
         # Invalid because requesting local and pr.
         (
@@ -51,7 +51,7 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
         # Load from local directory.
         (
             {"dataset_ID": "woelfel2020virological", "local": "data"},
-            "d93f77da4babf4247f7775121adc749337f53f31",
+            "0fae1c755023b347002be6cf1551a2b79b31b19a",
         ),
     ],
 )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,27 +30,27 @@ def test_normalize_str(value: str, kwargs: dict, expected: str) -> None:
         # of the hash. However, this dataset is relatively stable and is unlikely to
         # need updates.
         (
-            {"dataset": "woelfel2020virological"},
+            {"dataset_ID": "woelfel2020virological"},
             "d93f77da4babf4247f7775121adc749337f53f31",
         ),
         # An old version of the Woelfel dataset from a PR before folder restructuring.
         (
-            {"dataset": "woelfel2020", "pr": 1},
+            {"dataset_ID": "woelfel2020", "pr": 1},
             "7bf4dabae5ba95b06a62f6102fee571b46068786",
         ),
         # The same old version of the Woelfel dataset using a commit reference.
         (
-            {"dataset": "woelfel2020", "ref": "534c30a"},
+            {"dataset_ID": "woelfel2020", "ref": "534c30a"},
             "7bf4dabae5ba95b06a62f6102fee571b46068786",
         ),
         # Invalid because requesting local and pr.
         (
-            {"dataset": "woelfel2020virological", "local": "data", "pr": 7},
+            {"dataset_ID": "woelfel2020virological", "local": "data", "pr": 7},
             ValueError,
         ),
         # Load from local directory.
         (
-            {"dataset": "woelfel2020virological", "local": "data"},
+            {"dataset_ID": "woelfel2020virological", "local": "data"},
             "d93f77da4babf4247f7775121adc749337f53f31",
         ),
     ],


### PR DESCRIPTION
## Description

**Individual level:**
- Create functions to extract sampling start and end date, first positive, and last positive from shedding dataset;
- Plot individual level of shedding duration information (see the example for `woelfel2020virological` below).
![Screenshot 2025-04-30 104543](https://github.com/user-attachments/assets/9876f905-f93a-4bb5-9688-413f85905d75)

**Study level:**
- Summarize the sample size, number of participants, min shedding duration, max shedding duration, and mean shedding duration by study, biomarker, and specimen;
- Plot study level of shedding duration information (see the example below).
![Screenshot 2025-04-30 104600](https://github.com/user-attachments/assets/c3c60e3a-f9c0-4a7b-8eb8-78a9e0c31dc4)

## Issues 

Currently, few dataset can not be loaded and plotted.

## Ideas

Run those functions as part of the Github action workflows and save the visualizations to an `output` folder. Then create a `md` report file that include those analysis results (as a dynamic meta analysis)?
