### PR TITLE
bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shedding-hub"
-version = "0.1.2"
+version = "0.1.3"
 readme = "README.md"
 description = "Data and statistical models for biomarker shedding."
 dependencies = [


### PR DESCRIPTION
## Summary
- Bumps `shedding-hub` package version from `0.1.2` to `0.1.3` in `pyproject.toml`

## Test plan
- [ ] CI Build check passes
- [ ] After merge to main, the PyPI publish workflow triggers and publishes `0.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)