### PR TITLE
fix: persist weekly metrics to unprotected metrics-data branch

### DIFF
--- a/.github/workflows/weekly-report.yaml
+++ b/.github/workflows/weekly-report.yaml
@@ -27,6 +27,25 @@ jobs:
             google-analytics-data \
             google-auth
 
+      - name: Restore metrics history from metrics-data branch
+        run: |
+          # The accumulating snapshot history lives on the unprotected metrics-data
+          # branch (main is protected and rejects direct pushes). Seed the working
+          # copy with the full history so the report script appends to it rather than
+          # to main's stale one-record seed.
+          if git ls-remote --exit-code --heads origin metrics-data >/dev/null 2>&1; then
+            git fetch --depth=1 origin metrics-data
+            if git show FETCH_HEAD:metrics/weekly_metrics.jsonl > "$RUNNER_TEMP/history.jsonl" 2>/dev/null; then
+              mkdir -p metrics
+              cp "$RUNNER_TEMP/history.jsonl" metrics/weekly_metrics.jsonl
+              echo "Restored $(grep -c . metrics/weekly_metrics.jsonl) record(s) from metrics-data."
+            else
+              echo "metrics-data exists but has no metrics file yet; keeping main's seed."
+            fi
+          else
+            echo "metrics-data branch does not exist yet; using main's file as the seed."
+          fi
+
       - name: Run weekly report
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -40,10 +59,33 @@ jobs:
           REPORT_TO_EMAIL: ${{ secrets.REPORT_TO_EMAIL }}
         run: python scripts/weekly_report.py
 
-      - name: Commit metrics snapshot
+      - name: Persist metrics snapshot to metrics-data branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add metrics/weekly_metrics.jsonl
-          git diff --cached --quiet || git commit -m "chore: add weekly metrics snapshot $(date -u +%Y-%m-%d)"
-          git push
+
+          # The report script appended this week's record to the history we restored
+          # above. Commit it onto the dedicated, unprotected metrics-data branch via an
+          # isolated worktree so the protected main branch is never touched.
+          cp metrics/weekly_metrics.jsonl "$RUNNER_TEMP/weekly_metrics.jsonl"
+
+          if git ls-remote --exit-code --heads origin metrics-data >/dev/null 2>&1; then
+            git fetch --depth=1 origin metrics-data
+            git worktree add -B metrics-data "$RUNNER_TEMP/md" FETCH_HEAD
+          else
+            # First run: create metrics-data as a clean orphan branch holding only metrics.
+            git worktree add --detach "$RUNNER_TEMP/md"
+            git -C "$RUNNER_TEMP/md" checkout --orphan metrics-data
+            git -C "$RUNNER_TEMP/md" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p "$RUNNER_TEMP/md/metrics"
+          cp "$RUNNER_TEMP/weekly_metrics.jsonl" "$RUNNER_TEMP/md/metrics/weekly_metrics.jsonl"
+          git -C "$RUNNER_TEMP/md" add metrics/weekly_metrics.jsonl
+          if git -C "$RUNNER_TEMP/md" diff --cached --quiet; then
+            echo "No new metrics to commit."
+          else
+            git -C "$RUNNER_TEMP/md" commit -m "chore: weekly metrics snapshot $(date -u +%Y-%m-%d)"
+            git -C "$RUNNER_TEMP/md" push origin metrics-data
+            echo "Pushed metrics snapshot to metrics-data."
+          fi

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,20 @@
+# Weekly metrics
+
+The Weekly Report workflow (`.github/workflows/weekly-report.yaml`) collects a
+snapshot of GitHub, PyPI, and Google Analytics metrics every Monday and appends
+one JSON record per week to `weekly_metrics.jsonl`.
+
+Because `main` is a protected branch and rejects direct pushes, the **live,
+accumulating history is stored on the dedicated `metrics-data` branch**, not on
+`main`. Each weekly run restores the history from `metrics-data`, appends the new
+record, and pushes it back to that branch.
+
+To read the full history:
+
+```bash
+git fetch origin metrics-data
+git show origin/metrics-data:metrics/weekly_metrics.jsonl
+```
+
+The copy of `weekly_metrics.jsonl` on `main` is only the initial seed and is not
+updated by the workflow.


### PR DESCRIPTION
## Problem

The **Weekly Report** workflow has failed on every scheduled run since 2026-04-06, and `metrics/weekly_metrics.jsonl` has been stuck at a single record (`2026-03-26`) for months.

Both symptoms share one root cause. The report script step **succeeds** every run — the failure is the final step pushing the snapshot directly to `main`:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] main -> main (protected branch hook declined)
##[error]Process completed with exit code 1.
```

`main` requires a PR + the `Build` status check + `enforce_admins`, so a raw `git push` is rejected. Each week the script appended a record on the runner, committed locally, then the push was rejected → job failed and the new record was lost. The lone surviving record only exists because it was merged via PR #154.

## Fix

Persist the accumulating history on a dedicated, **unprotected `metrics-data` branch** instead of `main`:

- **Restore** the full history from `metrics-data` before running the report, so records append to the accumulated file rather than main's stale seed.
- **Persist** the updated file onto `metrics-data` via an isolated `git worktree`, leaving the protected `main` branch untouched.
- **Bootstrap** `metrics-data` as a clean orphan branch on first run.

The push uses the default `GITHUB_TOKEN` (`contents: write`); `metrics-data` is unprotected so it succeeds, and `GITHUB_TOKEN` pushes don't retrigger CI. Added `metrics/README.md` documenting where the live data lives.

## Verification

- Local simulation (bootstrap → 3 weekly cycles → idempotent re-run): records accumulated correctly on `metrics-data` (4 records), `main` untouched (1 seed), re-run of same week added nothing — **PASS**.
- Workflow YAML parses cleanly.

After merge, trigger **Actions → Weekly Report → Run workflow** to bootstrap `metrics-data` and confirm a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
