### PR TITLE
Promote extraction vocabulary into the schema

### DIFF
--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -2,12 +2,19 @@
 $defs:
   negative_positive_number:
     description: >
-      A quantitative value, or a qualitative result. `positive` is a result above the
-      limit of detection but below the limit of quantification; `strong positive` and
-      `weak positive` are for studies reporting graded immunoassay intensities (e.g.
-      +++/+), and should only be used when the study itself reports such a scale;
-      `negative` is a result below the limit of detection; `inconclusive` is an
-      indeterminate result, which is not the same as a weak one.
+      A quantitative value, or a qualitative result.
+
+      `positive` is a plain detected result, including one above the limit of detection
+      but below the limit of quantification. `strong positive` and `weak positive` are
+      for studies that grade a positive rather than reporting a single `positive` --
+      any qualitative or semiquantitative readout, such as +/++/+++, high/low positive,
+      borderline, or band and signal strength. Record the grade the study reports; do
+      not infer one from a numeric value, and do not invent a grade a study did not
+      report.
+
+      `negative` is a result below the limit of detection. `inconclusive` is an
+      indeterminate result the study could not resolve, which is not the same as a weak
+      one.
     oneOf:
       - type: number
         exclusiveMinimum: 0 # Zero should be coded as `negative`.

--- a/data/.schema.yaml
+++ b/data/.schema.yaml
@@ -2,13 +2,17 @@
 $defs:
   negative_positive_number:
     description: >
-      A quantitative value, `positive` result above limit of detection but below limit
-      of quantification, `inconclusive` result not conclusive for test output, or `negative` result below the limit of detection.
+      A quantitative value, or a qualitative result. `positive` is a result above the
+      limit of detection but below the limit of quantification; `strong positive` and
+      `weak positive` are for studies reporting graded immunoassay intensities (e.g.
+      +++/+), and should only be used when the study itself reports such a scale;
+      `negative` is a result below the limit of detection; `inconclusive` is an
+      indeterminate result, which is not the same as a weak one.
     oneOf:
       - type: number
         exclusiveMinimum: 0 # Zero should be coded as `negative`.
       - type: string
-        enum: [positive, negative, inconclusive]
+        enum: [strong positive, positive, weak positive, negative, inconclusive]
   specimen_type_enum:
     type: string
     enum:
@@ -20,9 +24,15 @@ $defs:
       - nasopharyngeal_swab
       - anterior_nares_swab
       - saliva
+      - buccal_swab
       - rectal_swab
+      - anorectal_swab
+      - genital_swab
       - unknown
       - bronchoalveolar_lavage_fluid
+      - tracheal_aspirate
+      - nasal_lavage_fluid
+      - nasal_discharge
       - serum
       - emesis
   analyte_specification:
@@ -79,6 +89,7 @@ $defs:
           - rotavirus vaccine
           - hepatitis A virus
           - hepatitis E virus
+          - mpox
       gene_target:
         description: The gene being targeted in qPCR or ddPCR if a genomic biomarker.
           This field should be left empty for non-genomic biomarkers, e.g., drug
@@ -92,8 +103,10 @@ $defs:
           - gc/mL
           - gc/swab
           - gc/wet gram
+          - gc/reaction
           - cycle threshold
           - pfu/mL
+          - vp/mL
       reference_event:
         description: Event used as reference for `time` fields of measurements.
         type: string
@@ -103,6 +116,9 @@ $defs:
           - enrollment
           - hospital admission
           - vaccination
+          - inoculation
+          - exposure
+          - treatment
       dose:
         description: >
           Vaccine dose number for vaccine shedding studies (e.g., 1, 2, 3).
@@ -172,6 +188,12 @@ properties:
       required:
         - measurements
       properties:
+        patient_id:
+          description: >
+            Identifier of the subject/patient from the data source (e.g., the PatientID
+            column). Retained for traceability; groups all of a subject's measurements
+            into one participant.
+          type: [string, integer]
         attributes:
           type: object
           properties:
@@ -221,11 +243,14 @@ properties:
                 - not hispanic
                 - unknown
             vaccinated:
-              description: If the participant was vaccinated against the condition.
+              description: >
+                Whether the participant was vaccinated against the condition. This is a
+                yes/no question: a participant vaccinated after exposure was still
+                vaccinated, so use true and leave the timing to the dataset description.
               oneOf:
                 - type: boolean
                 - type: string
-                  constant: unknown
+                  const: unknown
             lineage:
               description: Lineage information of the pathogen for the participant.
               type: string
@@ -245,17 +270,31 @@ properties:
                 - type: boolean
                 - type: string
                   const: unknown
+            subtype:
+              description: >
+                Pathogen type/subtype of the participant's infection as a single string.
+                For influenza, the type and (when reported) subtype or lineage, e.g.,
+                'A(H1N1)pdm09', 'A(H3N2)', 'B', 'B/Victoria'.
+              type: string
             participant_type:
               description: >
                 Type or category of participant (e.g., 'patient', 'healthcare worker',
                 'household contact', 'community control', 'index case').
               type: string
+            hospitalized:
+              description: >
+                Whether the participant was hospitalized. Use true for inpatients,
+                false for outpatients.
+              oneOf:
+                - type: boolean
+                - type: string
+                  const: unknown
             infant:
               description: If the participant was an infant.
               oneOf:
                 - type: boolean
                 - type: string
-                  constant: unknown
+                  const: unknown
             full_term:
               description: >
                 Whether the infant was born full term.
@@ -263,7 +302,7 @@ properties:
               oneOf:
                 - type: boolean
                 - type: string
-                  constant: unknown
+                  const: unknown
         measurements:
           type: array
           minItems: 1


### PR DESCRIPTION
## Why

The extraction pipeline has moved ahead of this schema. **14 of its 34 current outputs are rejected here despite being correct** — the data describes real science the schema has no words for.

The clearest case: `rouphael2025effective` is a controlled human infection study. Its reference event genuinely *is* `inoculation`, and it genuinely samples `buccal_swab`. The schema has neither, so the study cannot be represented at all. "Fixing" the data would mean falsifying it.

## What

Every change is additive except the last.

| Change | Note |
|---|---|
| `specimen` += `buccal_swab`, `anorectal_swab`, `genital_swab`, `tracheal_aspirate`, `nasal_lavage_fluid`, `nasal_discharge` | multi-site sampling studies |
| `reference_event` += `inoculation`, `exposure`, `treatment` | challenge and contact-tracing designs |
| `biomarker` += `mpox` | |
| `unit` += `gc/reaction`, `vp/mL` | assay reporting variation |
| `value` += `strong positive`, `weak positive` | see below |
| `participants` += `patient_id` | see below |
| `attributes` += `subtype`, `hospitalized` | `subtype` is **already used 478×** in `tsang2016individual`, validating only because `attributes` sets no `additionalProperties` |
| `constant:` → `const:` on `vaccinated`, `infant`, `full_term` | a real bug — see below |

### `strong positive` / `weak positive` are not a duplicate of `positive`

They're a study's own semiquantitative immunoassay scale. `li2018faecal` transcribed one straight from its source table:

> "Results reported qualitatively/semiquantitatively in table (e.g., **+ (weak positive), ++ (positive), +++ (strong positive)**)"

`inconclusive` is an indeterminate result — a different concept, not an intensity. The two vocabularies are orthogonal rather than competing, which is why each schema rejected the other's values. The description now states when each applies.

### `patient_id`

Its absence is why `kissler2021densely` and `kissler2021viral` carry `person_id` inside `attributes` — 133 participants using an open object to hold an identifier the schema forbids one field over. Adding it lets that workaround be retired.

### The `constant:` bug

```yaml
oneOf:
  - type: boolean
  - type: string
    constant: unknown      # not a JSON Schema keyword
```

Validators ignore unknown keywords, so the branch collapses to a bare `type: string` — **`vaccinated`, `infant` and `full_term` have been accepting any string.** Demonstrated: `vaccinated: "BANANA"` validates with **0 errors**, while `symptomatic: "BANANA"` is correctly rejected because it uses `const:`.

This is the only change that *tightens* validation, so the corpus was swept first: every `vaccinated`/`infant`/`full_term` value across all 55 datasets is a boolean or `'unknown'`. **Nothing is newly rejected.**

## Verification

```
$ pytest tests/test_data.py -k "test_data_validity or examples"
60 passed
```

All 55 datasets still validate, and `test_invalid_examples` still fails as it should — the schema has not become permissive.

Impact on the extraction corpus, with **no data changes**: files flagged drop from **15 → 3**, and vocabulary-drift findings from **191 → 0**. The 3 remaining are genuine data bugs, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)