### PR TITLE
fix: declare the Python 3.10 floor the code has always had

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,8 @@ jobs:
         run: |
           python - <<'PY'
           import glob, zipfile
-          names = zipfile.ZipFile(glob.glob("dist/*.whl")[0]).namelist()
+          zf = zipfile.ZipFile(glob.glob("dist/*.whl")[0])
+          names = zf.namelist()
           tops = {n.split("/")[0] for n in names}
           allowed = {"shedding_hub"} | {t for t in tops if t.endswith(".dist-info")}
           assert tops <= allowed, f"wheel ships unexpected top-level entries: {sorted(tops - allowed)}"
@@ -47,12 +48,40 @@ jobs:
               "the shipped catalog is missing from the wheel; load_shedding_catalog() "
               "would fail for every pip user"
           )
+          meta = zf.read(next(n for n in names if n.endswith(".dist-info/METADATA"))).decode()
+          assert "Requires-Python:" in meta, (
+              "the wheel declares no Requires-Python, so pip installs it on interpreters "
+              "too old to import it -- which is how 0.2.1 reached Python 3.9 users"
+          )
           print("wheel contents OK:", sorted(tops))
           PY
       - name: Build the documentation
         run: |
           python scripts/build_doc_figures.py
           python -m mkdocs build --strict
+  # Every other job runs 3.11, so "works on the oldest Python we claim to
+  # support" was never a tested claim -- 0.2.1 shipped `int | None` annotations
+  # that cannot be imported below 3.10 and nothing noticed. This job is the
+  # claim's only enforcement; keep its python-version equal to the lower bound
+  # of requires-python in pyproject.toml.
+  minimum-python:
+    name: Minimum supported Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      # Deliberately not requirements.txt: those pins (numpy 2.3.5, scipy
+      # 1.16.3) themselves need 3.11+, so they cannot be installed here at all.
+      # Installing the project resolves the dependency versions a real 3.10
+      # user gets, which is the combination actually worth testing.
+      - name: Install the package as a user would
+        run: pip install . pytest jsonschema
+      - name: Run tests
+        run: pytest -q
   data-validation:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Datasets are extracted from appendices, figures, and supplementary materials of 
 
 ## 📊 Getting the Data
 
-You can obtain the data by [downloading it from GitHub](https://github.com/shedding-hub/shedding-hub/tree/main/data). We also provide a [convenient Python package](http://pypi.org/project/shedding-hub/) so you can download the most recent data directly in your code or obtain a specific version of the data for reproducible analysis. Install the package by running `pip install shedding-hub` from the command line. The example below downloads the [data from Wölfel et al. (2020)](https://shedding-hub.github.io/datasets/woelfel2020virological.html) as of the commit [`259ca0d`](https://github.com/shedding-hub/shedding-hub/commit/259ca0d).
+You can obtain the data by [downloading it from GitHub](https://github.com/shedding-hub/shedding-hub/tree/main/data). We also provide a [convenient Python package](http://pypi.org/project/shedding-hub/) so you can download the most recent data directly in your code or obtain a specific version of the data for reproducible analysis. Install the package by running `pip install shedding-hub` from the command line; it requires Python 3.10 or newer. The example below downloads the [data from Wölfel et al. (2020)](https://shedding-hub.github.io/datasets/woelfel2020virological.html) as of the commit [`259ca0d`](https://github.com/shedding-hub/shedding-hub/commit/259ca0d).
 
 ```python
 >>> import shedding_hub as sh

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,8 @@
 pip install shedding-hub
 ```
 
+Python 3.10 or newer is required.
+
 This page walks the whole arc: load a curated study, describe it, fit a
 shedding curve to it, and simulate synthetic individuals from fitted
 parameters. The [tutorial](tutorial.md) goes deeper on the last step.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ preprocessing yourself.
 pip install shedding-hub
 ```
 
+Python 3.10 or newer is required.
+
 ## What it does
 
 === "Load"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,14 @@
 [project]
 name = "shedding-hub"
-version = "0.2.1"
+version = "0.2.2"
 readme = "README.md"
 description = "Data and statistical models for biomarker shedding."
+# The package annotates with PEP 604 unions (`int | None`), which the
+# interpreter evaluates as a module is imported, so 3.10 is a hard floor.
+# Every release through 0.2.1 declared no floor at all, so pip on 3.9 installed
+# them and `import shedding_hub` died on the first such annotation with
+# "TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'".
+requires-python = ">=3.10"
 dependencies = [
     "pyaml",
     "requests",


### PR DESCRIPTION
## The report

A user hit this on `pip install shedding-hub` in a Python 3.9 environment:

```
File ".../site-packages/shedding_hub/__init__.py", line 9, in <module>
  from .shedding_peak import (
File ".../site-packages/shedding_hub/shedding_peak.py", line 379, in <module>
  x_axis_upper_limit: int | None = 50,
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Root cause, in two layers

**The code really does require 3.10+.** It uses PEP 604 union annotations (`int | None`) in roughly 90 places across 13 modules, in function-parameter and dataclass-field positions that the interpreter evaluates as the module is imported. `shedding_peak.py:379` is just the first one `__init__.py` reaches.

**But nothing said so.** `pyproject.toml` declared no `requires-python`, so all six releases (0.1.0 through 0.2.1) sit on PyPI with `Requires-Python: null`. pip on 3.9 saw no reason not to install a package that cannot import.

It was invisible to CI by construction: all six workflow jobs run 3.11, and the pinned `requirements.txt` (numpy 2.3.5, scipy 1.16.3) cannot be installed below 3.11 anyway.

## Changes

- **`requires-python = ">=3.10"`**, with the version bumped to 0.2.2. The bump is load-bearing: `publish.yaml` uses `skip-existing: true`, so re-publishing 0.2.1 would be silently skipped and the metadata would never reach PyPI.
- **A `minimum-python` CI job** on 3.10 that installs the project the way a user does — `pip install .`, deliberately not `requirements.txt`, whose pins can't resolve there — and runs the suite. This is the only enforcement of the floor, so its `python-version` must stay equal to the lower bound in `pyproject.toml`.
- **The wheel-contents check now asserts `Requires-Python` is present**, so a wheel that advertises no floor cannot ship again.
- **Install docs** in `README.md`, `docs/index.md`, and `docs/getting-started.md` now state the requirement.

## Why 3.10 and not 3.11

Tested rather than assumed. On a real 3.10.11 interpreter, with the dependency versions pip resolves there (numpy 2.2.6, scipy 1.15.3, pandas 2.3.3, matplotlib 3.10.9), **all 562 tests pass**. The rebuilt wheel declares `Requires-Python: >=3.10`; pip refuses it on 3.9 with `Package 'shedding-hub' requires a different Python: 3.9.0 not in '>=3.10'` and accepts it on 3.10. `black --check`, the README doctests, and `mkdocs build --strict` are clean.

## What this does not fix

Publishing 0.2.2 will not unblock the reporter. Because 0.2.1 and earlier carry no `Requires-Python`, pip on 3.9 will skip 0.2.2 as incompatible, fall back to 0.2.1, and install the same broken version. Published metadata cannot be amended retroactively — yanking the older releases is the only way to make pip fail cleanly there, which affects anyone pinning them and is left as a separate decision.

The answer for the reporter is therefore an environment on Python 3.10+. Supporting 3.9 instead would mean `from __future__ import annotations` in all 13 modules *and* working against numpy 2.0 / scipy 1.13, the newest that install on 3.9 and which nothing has tested — for a Python that reached end of life in October 2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
