### PR TITLE
ci: notify the dashboard when data lands on main

### DIFF
--- a/.github/workflows/sync-dashboard.yaml
+++ b/.github/workflows/sync-dashboard.yaml
@@ -1,0 +1,24 @@
+name: Sync Dashboard
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "data/**"
+  workflow_dispatch:
+
+jobs:
+  notify-dashboard:
+    name: Notify
+    runs-on: ubuntu-latest
+    steps:
+      # `event-type` must stay `data-updated`: the receiving workflow,
+      # shedding-hub-dash/.github/workflows/sync-data.yml, filters on that exact
+      # name. GITHUB_TOKEN cannot dispatch across repositories, hence the PAT.
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          repository: shedding-hub/shedding-hub-dash
+          event-type: data-updated


### PR DESCRIPTION
`shedding-hub-dash/.github/workflows/sync-data.yml` already accepts a `repository_dispatch` of type `data-updated`:

```yaml
repository_dispatch:
  # Allow triggering from shedding-hub repo via webhook
  types: [data-updated]
```

Nothing has ever sent that event. The only dispatch sender here is `github-pages.yaml`, which targets a different repository (`shedding-hub.github.io`) with a different event type (`dispatch-event`). So the dashboard has only ever refreshed on its weekly Sunday-midnight-UTC cron or a manual run — #170 had to be synced by hand.

This adds the missing sender. It mirrors `github-pages.yaml`: same action, same `PERSONAL_ACCESS_TOKEN`, since `GITHUB_TOKEN` cannot dispatch across repositories.

## Two choices worth reviewing

**Scoped to `data/**` rather than every push to main.** The dashboard reads only the YAML datasets — `app.py` loads them straight from its synced `data/` folder and touches nothing else from this repo. A code or docs commit would make it re-sync and redeploy for nothing.

**`workflow_dispatch` kept.** Lets the notification be re-fired without a push, and gives a way to test the token without waiting for a data merge.

## Known unknown: PAT scope

`PERSONAL_ACCESS_TOKEN` exists in this repo's secrets and demonstrably works for `shedding-hub.github.io`. Whether its scope reaches `shedding-hub-dash` is unverified — if it is a fine-grained token scoped to selected repositories, the dash may not be among them, and the dispatch step will fail with a 404 rather than an obvious permissions error.

Running the workflow manually once after merge is the cheap check. If it 404s, add `shedding-hub-dash` to the token's repository access.

## Note on timing

A `push`-triggered workflow only takes effect once it is on the default branch, so this applies to the next data merge, not retroactively. The `data/**` filter means it will not run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
