### PR TITLE
Open the figures pull request with the personal access token

### DIFF
--- a/.github/workflows/refresh-figures.yaml
+++ b/.github/workflows/refresh-figures.yaml
@@ -57,6 +57,17 @@ jobs:
       - name: Open a pull request if anything changed
         uses: peter-evans/create-pull-request@v7
         with:
+          # GITHUB_TOKEN cannot open the pull request: this repository has
+          # "Allow GitHub Actions to create and approve pull requests" turned
+          # off, and a workflow-level permissions block cannot override that --
+          # the first run pushed its branch and then failed on the API call.
+          # The same personal access token the dispatch workflows already use
+          # opens it as a person instead.
+          #
+          # It also means the pull request runs CI. A pull request opened with
+          # GITHUB_TOKEN deliberately does not trigger workflows, so the figures
+          # would otherwise arrive unchecked.
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           add-paths: figures
           branch: figures/refresh
           # Reused rather than accumulating one branch per run: successive


### PR DESCRIPTION
`GITHUB_TOKEN` cannot create pull requests in this repository — `can_approve_pull_request_reviews` is `false`, and a workflow-level `permissions:` block cannot override it:

```
##[error]GitHub Actions is not permitted to create or approve pull requests.
```

The workflow pushed its branch successfully and then failed on the API call, so #174 had to be opened by hand.

This uses the `PERSONAL_ACCESS_TOKEN` secret the dispatch workflows (`sync-dashboard.yaml`, `github-pages.yaml`) already rely on, so the PR is opened as a person. That avoids changing a repository-wide security setting that would apply to every workflow here, not just this one.

**A second reason it's the better option:** a pull request opened with `GITHUB_TOKEN` deliberately does not trigger workflows. Had the permission simply been enabled, the figures PR would have arrived with no CI run at all. Opened with the token, it gets checked like any other.

**Trade-offs, stated plainly:** the token's expiry becomes something that can break this workflow, and the PR is authored by the token's owner rather than by the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB