### PR TITLE
Document cycle-threshold fitting, and the range view, in getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,75 @@ observations and the curve land on the same page:
 fig = sh.plot_fit_diagnostic(fit, data)
 ```
 
+![plot_fit_diagnostic](images/plot_fit_diagnostic.png)
+
+### Seeing what the fit implies, not just what it fitted
+
+The median individual says nothing about spread, which is most of what
+separates a usable fit from an unusable one. Widen the band to the full range
+of a simulated cohort and the page stops describing the curve and starts
+describing the population it would generate — which is what a simulation drawn
+from this fit will actually produce:
+
+```python
+fig = sh.plot_fit_diagnostic(
+    fit,
+    data,
+    band_quantiles=(0.0, 1.0),        # the whole simulated range, not its middle 90%
+    band_inner_quantiles=(0.025, 0.975),  # with the central 95% dashed inside it
+    band_sets_ylim=True,              # let that range widen the axis
+    x_from_fitted=True,               # and keep discarded readings from stretching time
+)
+```
+
+![plot_fit_diagnostic_range](images/plot_fit_diagnostic_range.png)
+
+A range is not a fixed property of the population: it grows with
+`n_simulated`, because drawing more individuals reaches further into the tails.
+Read it as what the fit considers *possible*, and the dashed lines as where the
+mass actually sits. This is the view the
+[dataset pages](https://shedding-hub.github.io/) carry, fitted under a stricter
+extrapolation gate — pass `max_peak_above_observed=2` to `fit_shedding_model`
+to reproduce it.
+
+## Fit cycle-threshold data
+
+**78 of the repository's 216 analytes report cycle thresholds** rather than
+concentrations — 31 datasets and 12,698 measurements. They are fitted by the
+same function, with no conversion and no assumption about PCR efficiency:
+
+```python
+data = sh.load_dataset("wang2020fecal")
+fit = sh.fit_shedding_model(data, analyte="stool_SARSCoV2_N", model="gamma")
+
+fit.value_type     # 'ct'
+fit.peak_day       # days to peak — comparable with a concentration fit
+fit.ct_cutoff      # the Ct at or above which a reading counts as a non-detect
+```
+
+![plot_fit_diagnostic_ct](images/plot_fit_diagnostic_ct.png)
+
+Because `Ct = α − β·log10 C` is affine, a gamma curve in concentration is a
+gamma curve in Ct, and the analyte is fitted on `CT_REFERENCE − Ct`. The
+unknown slope `β` multiplies both `a0` and `b0`, so it **cancels in `b0/a0`**:
+
+```python
+fit.comparable_with(concentration_fit)
+# ('peak_day', 't0', 'rise_days')
+```
+
+Peak time, onset and rise duration therefore compare across the two scales.
+Decay rate, half-life and peak height do not — they carry `β`, so a Ct fit's
+`half_life_days` is *not* a viral half-life. Heights are reported as Ct rather
+than log10, and the axis carries real Ct numbers.
+
+Two deliberate limits: the shipped catalog is concentration-only, so Ct fits
+need `fit_shedding_models(..., value_types=("ct",))` to build; and
+`simulate_shedding` **refuses a Ct source**, because turning cycles back into
+concentrations needs a standard curve the studies do not report. See
+[modeling methods](modeling-methods.md) for how far the cross-scale comparison
+actually gets you — the algebra is exact, the estimates less so.
+
 ## Use fits that are already computed
 
 You do not have to fit anything. The package ships a catalog of **144

--- a/docs/modeling-methods.md
+++ b/docs/modeling-methods.md
@@ -145,15 +145,25 @@ earliest reading, so a curve is never undefined at its own observations.
 
 | reason | n | meaning |
 |---|---|---|
-| `ct_units` | 207 | Cycle thresholds. Fittable directly with `fit_shedding_model`, but excluded from the catalog: their heights are cycles below `CT_REFERENCE`, not log10 concentrations, so an ensemble cannot average them together |
-| `no_rise_observed` | 63 | Fewer than 50% of subjects peaked later than their first reading, leaving `b0` unidentifiable |
-| `no_pre_event_readings` | 61 | `gamma_shifted` only: no detected reading at or before day 0, so `t0` has nothing to locate |
-| `too_few_subjects` | 50 | No subject cleared the per-subject minimum |
+| `ct_units` | 234 | Cycle thresholds, **excluded from this catalog but not unfitted** — see below |
+| `no_rise_observed` | 69 | Fewer than 50% of subjects peaked later than their first reading, leaving `b0` unidentifiable |
+| `no_pre_event_readings` | 68 | `gamma_shifted` only: no detected reading at or before day 0, so `t0` has nothing to locate |
+| `too_few_subjects` | 59 | No subject cleared the per-subject minimum |
 | `degenerate_fit` | 31 | Too few subjects survived the checks above |
-| `too_few_subjects_for_population` | 24 | Too few subjects to estimate a covariance |
+| `too_few_subjects_for_population` | 26 | Too few subjects to estimate a covariance |
 | `non_pathogen_biomarker` | 12 | crAssphage, PMMoV, mtDNA — indicators, not shed pathogens |
 | `no_positive_measurements` | 4 | Nothing ever detected |
 | `no_data_after_reference_event` | 1 | Sampling stopped at day 0, so no post-event trajectory exists |
+
+`ct_units` is a routing decision, not a refusal. Cycle-threshold analytes **are**
+fitted — 50 converged fits over 23 studies at the time of writing — and those
+fits are what the [website's dataset pages](https://shedding-hub.github.io/)
+draw for a Ct analyte. They are kept out of *this* catalog because its heights
+are log10 concentrations and a Ct fit's are cycles below `CT_REFERENCE`, so an
+ensemble averaging the two would be averaging incommensurable quantities. Build
+them into a catalog of their own with
+`fit_shedding_models(datasets, value_types=("ct",))`, or fit one directly with
+`fit_shedding_model`, which needs no opting in at all.
 
 ### Cycle-threshold fits
 

--- a/examples/simulating-shedding.md
+++ b/examples/simulating-shedding.md
@@ -362,6 +362,31 @@ by_hand = sh.make_ensemble(
 print("hand-built components:", [f.dataset_id for f in by_hand.fits])
 ```
 
+#### One kind of fit you cannot simulate from
+
+A fit of your own may well be a **cycle-threshold** fit — 78 of the
+repository's 216 analytes report Ct rather than concentration, and
+`fit_shedding_model` fits them directly. `simulate_shedding` refuses
+such a source, raising rather than returning numbers:
+
+    ValueError: This fit was estimated on cycle thresholds, and
+    simulation produces concentrations.
+
+That is deliberate. A Ct fit's height is cycles below `CT_REFERENCE`,
+and converting it to a concentration needs the assay's standard curve,
+which the studies do not report. Simulating anyway would exponentiate
+cycles as though they were log10 concentrations — a fit peaking 13.5
+cycles below the reference would silently claim 3.2e13 gc/mL.
+`make_ensemble` refuses a mixed set for the same reason.
+
+What does carry across is timing. `fit.comparable_with(other)` returns
+`('peak_day', 't0', 'rise_days')` for a Ct-versus-concentration pair,
+because the unknown standard-curve slope multiplies `a0` and `b0` alike
+and cancels in their ratio. So a Ct fit can tell you *when* a cohort
+peaks, and a concentration fit has to tell you *how high*. See
+[modeling methods](modeling-methods.md) for how far that comparison
+holds in practice.
+
 ### Whatever you choose, it stays auditable
 
 `selection.reason` names the rule that decided and `passed_over` is

--- a/scripts/build_doc_figures.py
+++ b/scripts/build_doc_figures.py
@@ -80,6 +80,32 @@ def main() -> int:
             sh.calc_shedding_peak(data, output="summary")
         ),
         "plot_fit_diagnostic": lambda: sh.plot_fit_diagnostic(fit, data),
+        # The variant the website's dataset pages carry: a stricter
+        # extrapolation gate, the full range of a simulated cohort rather than
+        # its central 90%, and the axis held to the readings the curve was
+        # fitted to. Refitted here rather than taken from the shipped catalog,
+        # which is built at the default gate of 3.
+        "plot_fit_diagnostic_range": lambda: sh.plot_fit_diagnostic(
+            sh.fit_shedding_model(
+                data, analyte="stool", model="gamma", max_peak_above_observed=2
+            ),
+            data,
+            band_quantiles=(0.0, 1.0),
+            band_inner_quantiles=(0.025, 0.975),
+            band_sets_ylim=True,
+            x_from_fitted=True,
+        ),
+        # A cycle-threshold fit, which no catalog ships: the axis carries real
+        # Ct numbers and the height is reported as a Ct rather than a log10.
+        # wang2020fecal is small enough to refit during a docs build.
+        "plot_fit_diagnostic_ct": lambda: sh.plot_fit_diagnostic(
+            sh.fit_shedding_model(
+                sh.load_dataset("wang2020fecal", local=str(REPO_ROOT / "data")),
+                analyte="stool_SARSCoV2_N",
+                model="gamma",
+            ),
+            sh.load_dataset("wang2020fecal", local=str(REPO_ROOT / "data")),
+        ),
         # A fitted analyte, drawn without its fit: the reference page is about
         # the layout, and using an unfittable analyte here would need a second
         # dataset loaded for one figure.


### PR DESCRIPTION
Two gaps on the docs site.

**Cycle thresholds appeared only in the modelling notes.** The page where someone learns to use the package never mentioned that **78 of the repository's 216 analytes** — 31 datasets, 12,698 measurements — can be fitted at all. There is now a *Fit cycle-threshold data* section covering:

- the same `fit_shedding_model` call, with no conversion and no assumed PCR efficiency
- why `β` cancels in `b0/a0`, so `peak_day`, `t0` and `rise_days` compare across scales while `a0`, half-life and height do not — a Ct fit's `half_life_days` is **not** a viral half-life
- the two deliberate limits: the shipped catalog is concentration-only, and `simulate_shedding` refuses a Ct source

**The range view was undocumented.** The default diagnostic shades the central 90% of a simulated cohort, which describes the curve; the full range with the central 95% dashed inside describes the population a simulation would draw. That is the view the [website's dataset pages](https://shedding-hub.github.io/) carry, so the docs and the site now explain the same picture, including how to reproduce the stricter gate with `max_peak_above_observed=2`.

Both figures are **generated** by `build_doc_figures.py`, not committed, so a change to either plot fails the docs build rather than leaving a stale image. The Ct figure refits `wang2020fecal` (10 subjects, 54 measurements) since no shipped catalog contains a Ct fit.

Every claim was checked against the running code rather than written from memory: `value_type == 'ct'`, `ct_cutoff == 40.0`, `comparable_with()` returning exactly `('peak_day', 't0', 'rise_days')`, and `simulate_shedding` genuinely raising on a Ct fit.

**Note on the fit counts** — they were already correct. All three pages say 144 fits over 48 studies, which matches the shipped catalog exactly (94 analytes, 93 exponential / 32 gamma / 19 gamma_shifted, 10 biomarkers, 18 specimens), so nothing needed changing there.

`mkdocs build --strict` passes with all three images resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB