### PR TITLE
Configure Dependabot so its alerts become pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+# The repository had vulnerability alerts switched on and automated security
+# fixes switched off, so it reported 78 problems it was never configured to
+# open a pull request about. Every one of them was in requirements.txt, and
+# almost all in the notebook toolchain that runs the extraction scripts --
+# jupyter-server, jupyterlab, nbconvert, tornado, mistune, pillow -- rather
+# than in anything the published package depends on, which is pyaml, requests,
+# pandas, matplotlib, numpy and scipy alone.
+#
+# Grouped deliberately. Ungrouped, a backlog that size opens a pull request per
+# package and each one re-runs a fourteen-minute build; grouped, the toolchain
+# moves as the single unit it actually is.
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # requirements.txt is pip-compiled from requirements.in, so a bumped pin
+    # stays consistent with the source: requirements.in names packages without
+    # pinning them. Re-run `pip-compile --upgrade` on Linux when the two do
+    # drift -- never on Windows, which resolves different markers.
+    open-pull-requests-limit: 5
+    groups:
+      notebook-toolchain:
+        patterns:
+          - "jupyter*"
+          - "nb*"
+          - "notebook"
+          - "ipython*"
+          - "tornado"
+          - "mistune"
+          - "bleach"
+          - "pillow"
+          - "Pillow"
+      everything-else:
+        patterns:
+          - "*"


### PR DESCRIPTION
The repository has **vulnerability alerts on** and **automated security fixes off**, so it has been reporting problems it was never configured to fix. 78 alerts accumulated — 1 critical, 43 high, 30 medium, 4 low.

## What the alerts actually are

All 78 sit in `requirements.txt`, and the top of the list is the notebook toolchain the extraction scripts use:

| package | alerts |
|---|---|
| `mistune` | 14 |
| `pillow` / `Pillow` | 19 |
| `tornado` | 10 |
| `jupyterlab` | 9 |
| `jupyter-server` | 5 (incl. the critical) |
| `nbconvert`, `notebook`, `bleach`, `urllib3`, … | rest |

**None is in what the published package depends on** — that is `pyaml`, `requests`, `pandas`, `matplotlib`, `numpy`, `scipy`. So nothing here ships to a `pip install shedding-hub` user.

The critical one is a stored XSS in `jupyter-server`'s `NbconvertFileHandler` (≤ 2.19.0, patched in 2.20.0). It needs a notebook server serving untrusted content to be exploitable, which is not what CI does with headless `nbconvert`. Worth fixing; not worth alarm.

## What this changes

Adds `.github/dependabot.yml` enabling **scheduled version updates** for pip, grouped so the backlog does not arrive as dozens of separate PRs each re-running a 14-minute build. Verified against the actual alerting packages: 9 of 12 fall into `notebook-toolchain`, the rest into `everything-else` — at most two PRs a week.

## What it does not change

**Automated security fixes are a repository setting, not a file**, so they remain off. Turning them on (Settings → Code security, or `gh api -X PUT repos/shedding-hub/shedding-hub/automated-security-fixes`) is what makes Dependabot open PRs for *alerts* specifically, as opposed to the scheduled upgrades this file configures. Either route clears the backlog; both together is the belt-and-braces version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB