### PR TITLE
Authenticate the GitHub API call, and retry doi resolution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,13 @@ jobs:
         run: black --check .
       - name: Run tests
         run: pytest -v --cov=shedding_hub --cov-report=term-missing
+        env:
+          # test_load resolves a pull request through api.github.com, which
+          # allows 60 requests an hour unauthenticated and has twice failed a
+          # run with "403 rate limit exceeded". Actions supplies this token to
+          # every workflow -- nothing has to be created for it -- and it raises
+          # the ceiling to 5,000.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run README doctests
         run: python -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE README.md
       - name: Build package
@@ -82,6 +89,8 @@ jobs:
         run: pip install . pytest jsonschema
       - name: Run tests
         run: pytest -q
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   data-validation:
     runs-on: ubuntu-latest
     steps:

--- a/shedding_hub/util.py
+++ b/shedding_hub/util.py
@@ -1,4 +1,5 @@
 import difflib
+import os
 import pathlib
 import re
 import requests
@@ -6,6 +7,31 @@ import textwrap
 from typing import Optional
 import warnings
 import yaml
+
+# Every network call here gets one. Without it a hung connection blocks until
+# the caller gives up, which in CI means a job sitting at its step timeout
+# rather than failing in seconds with something readable.
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def _github_api_headers() -> dict:
+    """
+    Authorization for api.github.com, when the environment offers a token.
+
+    The unauthenticated API allows 60 requests an hour per address, which a
+    busy CI account exhausts easily: ``test_load`` resolves a pull request
+    through it, and has twice failed a run with "403 rate limit exceeded".
+    A token raises that to 5,000, and GitHub Actions supplies one to every
+    workflow without any secret needing to be created.
+
+    Read from the environment rather than taken as an argument, because the
+    caller of ``load_dataset`` is usually a test or a notebook that should not
+    have to know about it. Sent only to ``api.github.com`` -- never to
+    ``raw.githubusercontent.com``, which needs no credential and should not be
+    handed one.
+    """
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    return {"Authorization": f"Bearer {token}"} if token else {}
 
 
 def normalize_str(
@@ -83,7 +109,11 @@ def load_dataset(
 
     # If a PR is specified, resolve it so we can get the relevant file.
     if pr:
-        response = requests.get(f"https://api.github.com/repos/{repo}/pulls/{pr}")
+        response = requests.get(
+            f"https://api.github.com/repos/{repo}/pulls/{pr}",
+            headers=_github_api_headers(),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
         response.raise_for_status()
         response = response.json()
         repo = response["head"]["repo"]["full_name"]
@@ -93,13 +123,18 @@ def load_dataset(
 
     # Download the contents and parse the file.
     ref = ref or "main"
+    # No Authorization header on these two: raw.githubusercontent.com serves
+    # public content without one, and a credential should not be sent where it
+    # is not needed.
     response = requests.get(
-        f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}/{dataset}.yaml"
+        f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}/{dataset}.yaml",
+        timeout=REQUEST_TIMEOUT_SECONDS,
     )
     # Backwards compatibility before change of folder structure.
     if response.status_code == 404:
         response = requests.get(
-            f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}.yaml"
+            f"https://raw.githubusercontent.com/{repo}/{ref}/data/{dataset}.yaml",
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
     response.raise_for_status()
     data = yaml.safe_load(response.text)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,12 +4,36 @@ from pathlib import Path
 import pytest
 import re
 import requests
+import time
 import yaml
 
 
 DATA_PATHS = list(Path("data").glob("*/*.yaml"))
 VALID_EXAMPLE_PATHS = list(Path("tests/examples").glob("valid_*.yaml"))
 INVALID_EXAMPLE_PATHS = list(Path("tests/examples").glob("invalid_*.yaml"))
+
+# Every dataset's doi is resolved against the publisher, so one run makes as
+# many requests as there are datasets -- 84 and climbing. Publishers drop
+# connections under that, and a single dropped connection failed a whole
+# 9-minute job with "RemoteDisconnected('Remote end closed connection without
+# response')". Retried rather than re-run: a transient refusal says nothing
+# about whether the doi resolves.
+DOI_RETRIES = 3
+DOI_BACKOFF_SECONDS = 2
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def _get_with_retry(url: str, **kwargs) -> requests.Response:
+    """GET a URL, retrying only transport failures -- never a real HTTP status."""
+    for attempt in range(DOI_RETRIES):
+        try:
+            return requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS, **kwargs)
+        except requests.exceptions.RequestException:
+            # The last attempt raises: a URL that never answers is a genuine
+            # failure of this check, not something to swallow.
+            if attempt == DOI_RETRIES - 1:
+                raise
+            time.sleep(DOI_BACKOFF_SECONDS * (attempt + 1))
 
 
 def load_and_validate(path: Path, skip_filename_check: bool = False):
@@ -38,12 +62,12 @@ def load_and_validate(path: Path, skip_filename_check: bool = False):
     doi_or_url = False
     doi = data.get("doi")
     if doi:
-        response = requests.get(f"https://doi.org/{doi}", allow_redirects=False)
+        response = _get_with_retry(f"https://doi.org/{doi}", allow_redirects=False)
         assert response.status_code == 302, f"doi `{doi}` could not be resolved."
         doi_or_url = True
     url = data.get("url")
     if url:
-        response = requests.get(url)
+        response = _get_with_retry(url)
         response.raise_for_status()
         doi_or_url = True
     assert doi_or_url, "At least one of `doi` or `url` must be given."

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -85,3 +85,56 @@ b: |
     )
     y = yaml.safe_load(io.StringIO(dumped))
     assert x == y
+
+
+def test_github_api_headers_uses_a_token_when_offered(monkeypatch) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "sekrit")
+    assert util._github_api_headers() == {"Authorization": "Bearer sekrit"}
+
+    # GH_TOKEN is what the gh CLI exports, so it is honoured too.
+    monkeypatch.delenv("GITHUB_TOKEN")
+    monkeypatch.setenv("GH_TOKEN", "other")
+    assert util._github_api_headers() == {"Authorization": "Bearer other"}
+
+
+def test_github_api_headers_are_empty_without_a_token(monkeypatch) -> None:
+    """Unauthenticated still has to work: the package is used outside CI."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert util._github_api_headers() == {}
+
+
+def test_token_goes_only_to_the_api_host(monkeypatch) -> None:
+    """A credential must not be sent where it is not needed.
+
+    raw.githubusercontent.com serves public content without one, so the token
+    belongs on the api.github.com request resolving the pull request and
+    nowhere else.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "sekrit")
+    seen = []
+
+    class _Response:
+        status_code = 200
+        text = "title: x\n"
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"head": {"repo": {"full_name": "o/r"}, "sha": "abc123"}}
+
+    def _fake_get(url, **kwargs):
+        seen.append((url, kwargs.get("headers") or {}, kwargs.get("timeout")))
+        return _Response()
+
+    monkeypatch.setattr(util.requests, "get", _fake_get)
+    util.load_dataset("somestudy", pr=1)
+
+    api = [s for s in seen if "api.github.com" in s[0]]
+    raw = [s for s in seen if "raw.githubusercontent.com" in s[0]]
+    assert api and raw, f"expected both hosts, saw {[s[0] for s in seen]}"
+    assert api[0][1] == {"Authorization": "Bearer sekrit"}
+    assert all(headers == {} for _, headers, _ in raw), "token leaked to raw host"
+    assert all(timeout is not None for _, _, timeout in seen), "a call had no timeout"


### PR DESCRIPTION
Two network flakes failed CI jobs today, each costing a re-run of a 6–15 minute job, and neither said anything about the code.

## Rate limit — `test_load`

```
403 Client Error: rate limit exceeded for url:
https://api.github.com/repos/shedding-hub/shedding-hub/pulls/1
```

`load_dataset(pr=...)` resolves a pull request through `api.github.com`, which allows **60 requests/hour per address** unauthenticated. A busy CI day exhausts that.

GitHub Actions **already supplies a token to every workflow** — nothing needs to be created or stored. The call now sends it when `GITHUB_TOKEN` or `GH_TOKEN` is set, raising the ceiling to 5,000, and the two test steps pass it through.

**The token goes to `api.github.com` alone.** `raw.githubusercontent.com` serves public content without a credential and should not be handed one — a test asserts that rather than trusting it.

## Dropped connection — `test_data_validity`

```
requests.exceptions.ConnectionError: ('Connection aborted.',
RemoteDisconnected('Remote end closed connection without response'))
```

One run resolves as many DOIs as there are datasets — 84 and climbing — and a publisher dropping a single connection failed the whole job. Transport failures now retry three times with backoff. **Any real HTTP status still fails as before**: a DOI that does not resolve is precisely what that check exists to catch.

## Timeouts

Every request in both files gets one. Without a timeout a hung connection sits until the step's own limit instead of failing in seconds with something legible.

## Verified

647 passed (644 + 3 new), `black --check` clean. The new tests cover the token being used, being absent, and not leaking to the raw-content host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB