### PR TITLE
Compile the lockfile on the Python that installs it

### DIFF
--- a/.github/workflows/relock.yaml
+++ b/.github/workflows/relock.yaml
@@ -27,13 +27,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        # 3.13, matching the header the committed lockfile carries. pip-compile
-        # resolves for the interpreter it runs on, so compiling under a
-        # different one rewrites the file for reasons that have nothing to do
-        # with upgrading it.
+        # The version that INSTALLS the lockfile, not the one that last
+        # compiled it. pip-compile resolves for the interpreter it runs on, so
+        # compiling on 3.13 picked scipy 1.18, which requires >=3.12, and the
+        # Build job -- running 3.11 -- then could not install the file at all.
+        # The committed lockfile carries a "compiled with Python 3.13" header
+        # for the same reason and had only been getting away with it.
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
       - name: Install pip-tools
         # The version the lockfile itself pins, so the tool cannot drift from
         # the file it maintains.


### PR DESCRIPTION
The relock workflow ran, opened #185, and three CI jobs failed in under twenty seconds — before a single test ran:

```
Install dependencies    failure
```

**Cause:** the workflow compiled on Python 3.13, so pip-compile chose `scipy==1.18.0`, which declares `requires_python >= 3.12`. The Build job runs **3.11** and cannot install it.

My reasoning in #184 was wrong. I pinned 3.13 to "match the header the committed lockfile carries", but that header records what *last compiled* the file — what matters is the interpreter that has to **install** it.

**This is older than the workflow.** The committed `requirements.txt` also says "compiled with Python 3.13" while CI installs it on 3.11. It had simply been getting away with it, because the SciPy it happened to pin still supported 3.11. The relock exposed the mismatch by upgrading into a version that doesn't.

Compiling on 3.11 — the version that actually installs the lockfile — removes the luck.

Once this merges, re-running `Relock Dependencies` should produce an installable lockfile. #185 is superseded and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB