### PR TITLE
Refresh the figures only when a dataset changes

### DIFF
--- a/.github/workflows/refresh-figures.yaml
+++ b/.github/workflows/refresh-figures.yaml
@@ -11,11 +11,11 @@ name: Refresh Dataset Figures
 # checks, with enforce_admins on, so GITHUB_TOKEN cannot push to it -- the first
 # version tried and was rejected with GH006.
 #
-# It triggers on data/** alone. Fits are not bit-reproducible across platforms
-# (tests/test_parameter_export.py carries DRIFT_RTOL for the same reason), so a
-# Linux runner re-rendering figures generated elsewhere always finds
-# differences: the first run rewrote 286 files and found four analytes whose
-# optimisation converged here but had not locally. Every code change would
+# It triggers on the dataset files alone. Fits are not bit-reproducible across
+# platforms (tests/test_parameter_export.py carries DRIFT_RTOL for the same
+# reason), so a Linux runner re-rendering figures generated elsewhere always
+# finds differences: the first run rewrote 286 files and found four analytes
+# whose optimisation converged here but had not locally. Every code change would
 # otherwise raise a pull request full of visually identical binaries. Refresh
 # after a code change by hand with workflow_dispatch, once, rather than on each
 # commit.
@@ -24,8 +24,26 @@ on:
   push:
     branches:
       - main
+    # `data/*/*.yaml`, not `data/**`. Everything a figure is drawn from reaches
+    # it through these files: the gate-2 catalogs are built from `data/*/*.yaml`
+    # and the renderer reads the catalogs, nothing else. The rest of data/ --
+    # the digitized CSVs, the extraction notebooks, the source spreadsheets and
+    # PDFs -- cannot move a curve. Neither can `data/.schema.yaml`, which sits
+    # at the top of data/ and so falls outside a pattern that requires a study
+    # directory: adding a biomarker or a treatment to the vocabulary changes no
+    # measurement.
+    #
+    # Under `data/**` each of those merges cost a 45-minute run whose only
+    # output was a pull request full of visually identical binaries. Two of the
+    # five runs between 2026-08-21 and 2026-08-25 were exactly that, both
+    # schema-only.
+    #
+    # Deliberately not narrowed to *added* datasets. Correcting a value in a
+    # study already here changes its curve, and a stale figure is the failure
+    # this workflow exists to prevent -- #192 rewrote eleven viral loads and
+    # genuinely needed the re-render.
     paths:
-      - "data/**"
+      - "data/*/*.yaml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The trigger was `data/**`, which is far wider than what a figure is actually drawn from — so merges that could not possibly move a curve were each costing a 45-minute run whose only output was a pull request full of visually identical binaries.

## What the figures depend on

Everything reaches a curve through `data/*/*.yaml`: the gate-2 catalogs are built from those files, and the renderer reads the catalogs and nothing else. The rest of `data/` — the digitized CSVs, the extraction notebooks, the source spreadsheets and PDFs — cannot change a fit.

Neither can `data/.schema.yaml`. It sits at the top of `data/`, so it falls outside a pattern that requires a study directory, which is exactly the point: adding a biomarker or a treatment to the vocabulary changes no measurement.

## Replayed against the last five runs

| PR | | `data/` files | dataset YAML | under `data/*/*.yaml` |
|---|---|---|---|---|
| #198 | add 8 adenovirus datasets | 16 | 8 | fires |
| #196 | add cidofovir to the vocabulary | 1 | 0 | **skipped** |
| #193 | add 9 norovirus datasets | 18 | 9 | fires |
| #192 | correct 11 HAV viral loads | 2 | 1 | fires |
| #189 | add a biomarker and specimen | 1 | 0 | **skipped** |

Two of five runs saved, both one-line schema additions, without losing a single run that mattered.

## One deliberate departure from the narrower reading

Not narrowed to *added* datasets. Correcting a value in a study already here changes its curve, and a stale figure is the precise failure this workflow exists to prevent — its own header says so. #192 rewrote eleven viral loads in `kamel2011presence` and genuinely needed the re-render; a filter keyed on new files would have skipped it and left a curve fitted to data that no longer exists.

`workflow_dispatch` is untouched, so a code change is still refreshed by hand, once, as before.