### PR TITLE
Rebuild the shipped catalog on a runner, on demand

### DIFF
--- a/.github/workflows/refresh-catalog.yaml
+++ b/.github/workflows/refresh-catalog.yaml
@@ -1,0 +1,160 @@
+name: Refresh Shedding Catalog
+
+# Rebuild the shipped catalog, the exported parameter tables and the counts
+# quoted in docs/, on a branch, on demand.
+#
+# Adding a dataset makes `test_shipped_catalog_covers_every_dataset` fail until
+# the catalog is regenerated, and Build is a required check, so a data pull
+# request cannot merge until someone runs `make catalog`. Doing that on a
+# laptop is the problem this workflow exists to solve: the fits are not
+# reproducible across platforms or across numpy and scipy versions. Rebuilding
+# a 121-dataset catalog on Windows against numpy 2.2.6 and scipy 1.15.3, where
+# CI pins 2.4.6 and 1.17.1, moved every one of the 163 pre-existing fits past
+# the 1e-4 tolerance the parameter export allows, dropped a converged gamma fit
+# from falsey2003comparison and gained one on peiris2003clinical -- a study the
+# batch had not touched. The same class of drift is documented in
+# refresh-figures.yaml, which found four analytes that converged on the runner
+# but had not locally.
+#
+# Building here instead pins the artifact to one environment: ubuntu, Python
+# 3.11, and requirements.txt, which is what the Build job runs and what the
+# wheel is built from.
+#
+# Deliberately workflow_dispatch with a `branch` input rather than a push
+# trigger. Refitting every analyte takes about a quarter of an hour, which is
+# far too slow to sit in the path of every commit, and the result is wanted
+# once per batch rather than once per push. Taking the target as an input, and
+# checking it out explicitly, also means the workflow only has to exist on the
+# default branch -- a data branch cut before this landed can still be refreshed
+# without merging main into it first.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to rebuild on and push the result back to."
+        required: true
+        type: string
+      dry_run:
+        description: "Build and report the diff, but push nothing."
+        type: boolean
+        default: false
+
+# Only the checkout token below can push. The default token is left read-only
+# so a mistake here cannot write to the repository through the ambient
+# permission.
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Rebuild the catalog on a branch
+    runs-on: ubuntu-latest
+    # The catalog build is roughly a quarter of an hour; the parameter export
+    # and the doc counts fit nothing and take seconds. Bounded well under the
+    # default ceiling so a fit that will not converge cannot burn a day.
+    timeout-minutes: 90
+
+    steps:
+      - name: Refuse to run against a protected branch
+        if: ${{ inputs.branch == 'main' }}
+        run: |
+          echo "::error::main is protected and takes changes through a pull request."
+          exit 1
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          # Not GITHUB_TOKEN. A push made with it does not trigger workflows,
+          # so Build would never re-run on the commit this job creates and the
+          # pull request would sit on the stale failing check it was meant to
+          # clear. The same personal access token the other dispatch workflows
+          # use pushes as a person, and CI runs.
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Equal to the Build job. The catalog is a published artifact -- it
+          # ships inside the wheel -- so it should be produced by the
+          # interpreter that builds the wheel, not merely a compatible one.
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Report the build environment
+        # Printed because the whole point of building here is that the answer
+        # depends on these versions. When a rebuild moves numbers unexpectedly,
+        # this is the first thing worth reading.
+        run: |
+          python -c "import numpy, scipy; print('numpy', numpy.__version__); print('scipy', scipy.__version__)"
+
+      - name: Rebuild the catalog
+        run: make catalog
+
+      - name: Export the parameter tables
+        run: make parameters
+
+      - name: Update the counts quoted in the docs
+        run: make doc_counts
+
+      - name: Validate the result
+        # The three staleness guards this job exists to satisfy, run before the
+        # commit rather than after the push, so a build that did not actually
+        # fix them fails here instead of on the pull request.
+        env:
+          SHEDDING_HUB_SKIP_LINK_CHECKS: "1"
+        run: |
+          pytest -q \
+            tests/test_shedding_catalog.py::test_shipped_catalog_covers_every_dataset \
+            tests/test_parameter_export.py
+          python scripts/update_doc_counts.py --check
+
+      - name: Summarize what changed
+        run: |
+          {
+            echo "### Catalog refresh on \`${{ inputs.branch }}\`"
+            echo
+            echo '```'
+            git diff --stat -- shedding_hub/data/shedding_catalog.yaml docs/
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit and push
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Scoped to the generated paths. `git commit -a` would sweep up
+          # anything else the build happened to leave in the tree, and the
+          # review PDFs and gate-2 catalogs at the repository root are exactly
+          # the kind of large binary that would ride along unnoticed.
+          git add \
+            shedding_hub/data/shedding_catalog.yaml \
+            docs/shedding_parameters.json \
+            docs/shedding_parameters.csv \
+            docs/getting-started.md \
+            docs/index.md \
+            docs/modeling-methods.md
+
+          if git diff --cached --quiet; then
+            echo "Catalog and derived files are already current; nothing to push."
+            exit 0
+          fi
+
+          git commit -F - <<EOF
+          catalog: rebuild after a data change
+
+          Regenerated by .github/workflows/refresh-catalog.yaml on
+          ${{ inputs.branch }}, with numpy and scipy as pinned in
+          requirements.txt.
+          EOF
+          git push origin HEAD:"${{ inputs.branch }}"
+
+      - name: Report a dry run
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "Dry run: built and validated, pushed nothing."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : backup_data assert_data_unchanged extraction catalog parameters review review_range catalog_ct review_ct review_ct_range catalog_ct_gate2 review_ct_gate2 review_ct_gate2_range catalog_gate2 figures curation_growth
+.PHONY : backup_data assert_data_unchanged extraction catalog parameters review review_range catalog_ct review_ct review_ct_range catalog_ct_gate2 review_ct_gate2 review_ct_gate2_range catalog_gate2 figures curation_growth doc_counts
 
 EXTRACTION_MARKDOWN = $(wildcard data/*/*-extraction.md)
 EXTRACTION_HTML = ${EXTRACTION_MARKDOWN:.md=.html}
@@ -43,6 +43,12 @@ catalog :
 # catalog. Fits nothing; run it after `make catalog`.
 parameters :
 	python scripts/export_parameter_table.py
+
+# Rewrite the catalog counts quoted in docs/. Reads the shipped catalog and
+# substitutes the numbers in place; run it after `make catalog`. `--check`
+# reports staleness without writing, which is what the test uses.
+doc_counts :
+	python scripts/update_doc_counts.py
 
 # The concentration catalog under a 2 log10 over-extrapolation gate, which is
 # what the website's dataset figures are drawn from. Note that the Ct build's

--- a/scripts/update_doc_counts.py
+++ b/scripts/update_doc_counts.py
@@ -1,0 +1,144 @@
+"""
+Rewrite the catalog counts quoted in the documentation.
+
+Three pages state how large the shipped catalog is, in prose: the fit count,
+the study count, the analyte count, the split by model, and the number of
+biomarkers and specimen types. Every one of those moves whenever the catalog is
+rebuilt, and nothing had been checking them -- the figures in `index.md` and
+`modeling-methods.md` are simply what someone typed after the last rebuild.
+
+Run via `make doc_counts`, after `make catalog`.
+
+This substitutes the numbers where they stand rather than regenerating the
+sentences around them. Rewriting the prose would reflow it and bury the real
+change in a whitespace diff; replacing digits in place leaves a diff that shows
+exactly which counts moved. The patterns are anchored on the surrounding words
+and each must match exactly once, so a page that has been reworded fails loudly
+here instead of silently keeping a stale number.
+"""
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from shedding_hub import load_shedding_catalog  # noqa: E402
+
+DOCS = REPO_ROOT / "docs"
+
+# `\s+` rather than a literal space throughout: every one of these sentences is
+# wrapped, and which words a line break falls between depends on how wide the
+# numbers happen to be. Anchoring on single spaces made the patterns miss
+# whenever a rebuild changed a count's digit width.
+PATTERNS = {
+    "getting-started.md": [
+        (
+            r"(catalog of \*\*)(\d+)(\s+converged fits over\s+)(\d+)( studies\*\*)",
+            ("fits", "studies"),
+        ),
+    ],
+    "index.md": [
+        (
+            r"(catalog of \*\*)(\d+)(\s+converged fits over\s+)(\d+)"
+            r"( studies\*\*, spanning\s+)(\d+)(\s+biomarkers and\s+)(\d+)"
+            r"(\s+specimen\s+types)",
+            ("fits", "studies", "biomarkers", "specimens"),
+        ),
+    ],
+    "modeling-methods.md": [
+        (
+            r"(The catalog currently holds \*\*)(\d+)(\s+fits over\s+)(\d+)"
+            r"(\s+studies and\s+)(\d+)(\s+analytes\*\*:\s+)(\d+)"
+            r"(\s+exponential,\s+)(\d+)(\s+gamma,\s+)(\d+)"
+            r"(\s+gamma_shifted, across\s+)(\d+)(\s+biomarkers)",
+            (
+                "fits",
+                "studies",
+                "analytes",
+                "exponential",
+                "gamma",
+                "gamma_shifted",
+                "biomarkers",
+            ),
+        ),
+    ],
+}
+
+
+def catalog_counts(catalog=None) -> dict:
+    """Every number the documentation quotes, read off the shipped catalog."""
+    catalog = load_shedding_catalog() if catalog is None else catalog
+    table = catalog.table
+    by_model = table["model"].value_counts()
+    return {
+        "fits": len(table),
+        "studies": table["dataset_id"].nunique(),
+        "analytes": table.groupby(["dataset_id", "analyte"]).ngroups,
+        "biomarkers": table["biomarker"].nunique(),
+        "specimens": table["specimen"].nunique(),
+        "exponential": int(by_model.get("exponential", 0)),
+        "gamma": int(by_model.get("gamma", 0)),
+        "gamma_shifted": int(by_model.get("gamma_shifted", 0)),
+    }
+
+
+def _substitute(text: str, pattern: str, names: tuple, counts: dict) -> str:
+    """Replace the captured numbers, leaving every other character alone."""
+
+    def repl(match: re.Match) -> str:
+        # Odd groups are the literal text around each number, even groups are
+        # the numbers themselves, in the order `names` lists them.
+        parts = list(match.groups())
+        for index, name in enumerate(names):
+            parts[2 * index + 1] = str(counts[name])
+        return "".join(parts)
+
+    updated, n = re.subn(pattern, repl, text)
+    if n != 1:
+        raise SystemExit(
+            f"pattern matched {n} time(s), expected exactly 1. The page has been "
+            f"reworded and this script needs updating:\n  {pattern}"
+        )
+    return updated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report whether the pages are current; write nothing. Exits 1 if stale.",
+    )
+    args = parser.parse_args()
+
+    counts = catalog_counts()
+    print("catalog counts:", ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+
+    stale = []
+    for name, patterns in PATTERNS.items():
+        path = DOCS / name
+        original = path.read_text(encoding="utf-8")
+        updated = original
+        for pattern, names in patterns:
+            updated = _substitute(updated, pattern, names, counts)
+        if updated == original:
+            print(f"  {name}: already current")
+            continue
+        stale.append(name)
+        if args.check:
+            print(f"  {name}: STALE")
+        else:
+            path.write_text(updated, encoding="utf-8")
+            print(f"  {name}: updated")
+
+    if args.check and stale:
+        print(f"\nStale: {', '.join(stale)}. Run `make doc_counts`.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a dispatchable workflow that rebuilds the shipped catalog, the exported parameter tables and the counts quoted in the docs, on a branch, using the same environment that runs Build.

## Why

Adding a dataset makes `test_shipped_catalog_covers_every_dataset` fail until the catalog is regenerated. `Build` is a required check with `enforce_admins` on, so a data pull request cannot merge until someone runs `make catalog`. Until now that has meant a laptop, and the last three data branches say "and rebuild the catalog" in their commit messages.

That is where the drift comes from. I rebuilt the 121-dataset catalog locally while preparing #204, on Windows with numpy 2.2.6 and scipy 1.15.3 against the pinned 2.4.6 and 1.17.1:

| Measure | Result |
|---|---|
| Pre-existing fits compared | 163 |
| Changed beyond the 1e-4 export tolerance | 163 |
| Studies affected | 58 of 58 |
| Converged fits dropped | 1 (`falsey2003comparison`, gamma) |
| Converged fits gained on an untouched study | 1 (`peiris2003clinical`, gamma) |

The diff was 7305 insertions against 5081 deletions, where the previous batch's was 517 against essentially none. `population_cov` moved on all 163 fits, `population_mean` on 161, `sigma` on 120.

The convergence changes are the part that matters. Which fits exist in a published artifact should not depend on whose machine built it. `refresh-figures.yaml` documents the same problem from the other direction, having found four analytes that converged on the runner but had not locally.

## What it does

Builds on ubuntu with Python 3.11 and `requirements.txt`, which is what runs Build and what the wheel is built from, then runs the three staleness guards before committing so a build that did not actually fix them fails in the job rather than on the pull request.

Two deliberate choices:

- **Dispatch takes the branch as an input** and checks it out explicitly, rather than relying on the ref it runs from. A data branch cut before this lands can be refreshed without merging main into it first.
- **It pushes with `PERSONAL_ACCESS_TOKEN`.** A push made with `GITHUB_TOKEN` does not trigger workflows, so Build would never re-run and the pull request would sit on the stale failing check this exists to clear. Same reasoning as `refresh-figures.yaml`.

It refuses to run against main, and `dry_run` builds and validates without pushing.

## The doc counts

`docs/getting-started.md`, `docs/index.md` and `docs/modeling-methods.md` quote the catalog's size in prose. Nothing was checking them, so they are whatever someone typed after the last rebuild. `scripts/update_doc_counts.py` reads the catalog and substitutes the numbers where they stand, which keeps the wrapping and makes the diff show which counts moved rather than a reflowed paragraph. Each pattern must match exactly once, so a reworded page fails loudly instead of silently keeping a stale number. `--check` reports staleness without writing.

Verified against the current catalog: it reports all three pages already current, and given a catalog with different counts it rewrites exactly the numbers and nothing else.

## Validation

```
664 passed
black --check .  ->  45 files would be left unchanged
```

## After this merges

Dispatch it against `data/add-20-agent-extracted-studies` to clear the failing check on #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6NxCZWQLc5NAbxAineEdC