### PR TITLE
Validate a catalog rebuild against the whole suite

### DIFF
--- a/.github/workflows/refresh-catalog.yaml
+++ b/.github/workflows/refresh-catalog.yaml
@@ -101,15 +101,30 @@ jobs:
         run: make doc_counts
 
       - name: Validate the result
-        # The three staleness guards this job exists to satisfy, run before the
-        # commit rather than after the push, so a build that did not actually
-        # fix them fails here instead of on the pull request.
+        # The whole suite, not the staleness guards alone, run before the commit
+        # rather than after the push so a build that did not actually fix them
+        # fails here instead of on the pull request.
+        #
+        # It was the two guards and the doc-count check on the first run, which
+        # proved too narrow to be worth much: three docstring examples under
+        # `shedding_hub/` read the fit count and a peak day straight off the
+        # catalog, and rebuilding moved all three. `testpaths` collects that
+        # tree, but naming test files explicitly skips it, so the stale
+        # doctests reached the pull request and failed Build there -- the exact
+        # failure this step exists to pre-empt. Narrowing it again to save a
+        # few minutes trades away the only thing it is for.
         env:
+          # Mirrors the Build job. test_load resolves a pull request through
+          # api.github.com, rate limited to 60 requests an hour
+          # unauthenticated; the thread pins stop each xdist worker spawning a
+          # BLAS pool per core and fighting the others.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHEDDING_HUB_SKIP_LINK_CHECKS: "1"
+          OMP_NUM_THREADS: "1"
+          OPENBLAS_NUM_THREADS: "1"
+          MKL_NUM_THREADS: "1"
         run: |
-          pytest -q \
-            tests/test_shedding_catalog.py::test_shipped_catalog_covers_every_dataset \
-            tests/test_parameter_export.py
+          pytest -q -n auto
           python scripts/update_doc_counts.py --check
 
       - name: Summarize what changed


### PR DESCRIPTION
Follow-up to #205, fixing a gap its first real use exposed.

## What went wrong

The `Validate the result` step ran only the two staleness guards and the doc-count check. That turned out to be too narrow. Three docstring examples under `shedding_hub/` read numbers straight off the catalog, and the rebuild for #204 moved all three:

| Example | Was | Now |
|---|---|---|
| `catalog.table.shape` | (164, 25) | (184, 25) |
| `len(catalog.fits)` | 164 | 184 |
| `round(fit.peak_day, 2)` | 1.18 | 1.1 |

`pyproject.toml` collects `shedding_hub` through `testpaths`, but naming test files explicitly on the command line skips it. So the job passed its own validation, pushed the rebuilt catalog to the branch, and Build failed on the pull request with three stale doctests. That is precisely the failure the step exists to pre-empt.

## The change

Run the whole suite, with the same environment the Build job uses. The token matters because `test_load` resolves a pull request through `api.github.com`, and the thread pins stop each xdist worker spawning a BLAS pool per core.

It costs a few minutes against a job that already spends about twenty refitting.

## Note

This does not update the doctests, it only catches them. They are a legitimate consequence of a rebuild and belong in the data pull request, which is where they went for #204. A future batch will see the rebuild job fail here, with the expected-versus-actual in the log, rather than finding out one pull request later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6NxCZWQLc5NAbxAineEdC