### PR TITLE
Skip analytes with nothing to plot instead of failing the render

### DIFF
--- a/docs/reference/visualisation.md
+++ b/docs/reference/visualisation.md
@@ -24,6 +24,8 @@
 
 ![plot_fit_diagnostic](../images/plot_fit_diagnostic.png)
 
+::: shedding_hub.NothingToPlotError
+
 ::: shedding_hub.plot_analyte_observations
 
 ![plot_analyte_observations](../images/plot_analyte_observations.png)

--- a/scripts/build_dataset_figures.py
+++ b/scripts/build_dataset_figures.py
@@ -32,6 +32,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from shedding_hub import (  # noqa: E402
+    NothingToPlotError,
     load_dataset,
     load_shedding_catalog,
     plot_analyte_observations,
@@ -90,6 +91,11 @@ def main() -> int:
     index: dict[str, dict] = {}
     n_fit = n_obs = 0
     failures: list[tuple[str, str, str]] = []
+    # Kept apart from failures on purpose. An analyte with nothing plottable is
+    # a property of the data, not a defect, and folding the two together is what
+    # let two qualitative-only analytes in gerna2007prospective fail a refresh
+    # that had already rendered 416 figures correctly.
+    skipped: list[tuple[str, str]] = []
 
     for dataset_id in dataset_ids:
         dataset = load_dataset(dataset_id, local=str(data_dir))
@@ -132,6 +138,12 @@ def main() -> int:
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore", UserWarning)
                         figure = plot_analyte_observations(dataset, analyte)
+                except NothingToPlotError:
+                    # Every reading is qualitative, so there are no axes to draw.
+                    # The analyte gets no figure and no index entry, the same as
+                    # one whose fits are all unusable.
+                    skipped.append((dataset_id, analyte))
+                    continue
                 except Exception as error:  # noqa: BLE001
                     failures.append((dataset_id, analyte, f"observations: {error}"))
                     continue
@@ -152,6 +164,10 @@ def main() -> int:
     total = sum(len(e["figures"]) for d in index.values() for e in d["analytes"])
     print(f"\nwrote {total} figure(s): {n_fit} fit, {n_obs} observations-only")
     print(f"index at {output / 'index.json'}")
+    if skipped:
+        print(f"{len(skipped)} analyte(s) had nothing to plot and were skipped:")
+        for dataset_id, analyte in skipped:
+            print(f"  {dataset_id} / {analyte}")
     if failures:
         print(f"{len(failures)} figure(s) could not be rendered:")
         for dataset_id, analyte, message in failures:

--- a/shedding_hub/__init__.py
+++ b/shedding_hub/__init__.py
@@ -19,6 +19,7 @@ from .viz import (
     plot_shedding_heatmap,
     plot_mean_trajectory,
     plot_catalog_fits,
+    NothingToPlotError,
     plot_analyte_observations,
     plot_fit_diagnostic,
     # Implemented since before 0.1.3 and documented on the project website, but
@@ -84,6 +85,7 @@ __all__ = [
     "plot_shedding_heatmap",
     "plot_mean_trajectory",
     "plot_catalog_fits",
+    "NothingToPlotError",
     "plot_analyte_observations",
     "plot_fit_diagnostic",
     "plot_clearance_curve",

--- a/shedding_hub/viz.py
+++ b/shedding_hub/viz.py
@@ -17,6 +17,41 @@ from .shedding_fit import (
     prepare_observations,
 )
 
+
+class NothingToPlotError(ValueError):
+    """
+    Raised when an analyte has no measurement that can be drawn.
+
+    A figure needs a numeric time paired with a usable value. An analyte whose
+    every reading is qualitative -- "positive" or "inconclusive", which the
+    schema allows and studies do report -- has neither, and no axes can show
+    it. That is a property of the data, not a fault, so it is raised as its own
+    type: a batch renderer can skip the analyte and keep going, while a genuine
+    plotting bug still surfaces as a failure. `SheddingDataError` does the same
+    job for the fitter, and the catalog builder skips 42 analytes on it without
+    complaint.
+
+    Subclasses ``ValueError`` so callers written against the older behaviour
+    keep working.
+
+    Examples:
+        >>> import shedding_hub as sh
+        >>> dataset = {
+        ...     'analytes': {'flu': {'biomarker': 'influenza',
+        ...                          'specimen': 'nasopharyngeal_aspirate',
+        ...                          'unit': 'gc/mL',
+        ...                          'reference_event': 'hospital admission'}},
+        ...     'participants': [{'measurements': [
+        ...         {'analyte': 'flu', 'time': 0, 'value': 'positive'}]}],
+        ... }
+        >>> try:
+        ...     sh.plot_analyte_observations(dataset, 'flu')
+        ... except sh.NothingToPlotError as error:
+        ...     print(type(error).__name__)
+        NothingToPlotError
+    """
+
+
 # Constants
 DEFAULT_BIOMARKER = "SARS-CoV-2"
 DEFAULT_FIGURE_SIZE = (8, 6)
@@ -3606,7 +3641,7 @@ def plot_analyte_observations(
                 n_qualitative += 1
 
     if not times:
-        raise ValueError(
+        raise NothingToPlotError(
             f"Analyte {analyte!r} of dataset "
             f"{dataset.get('dataset_id', '<unknown>')!r} has no measurement with "
             "both a numeric time and a usable value, so there is nothing to plot."

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -2035,3 +2035,36 @@ def test_analyte_observations_counts_qualitative_readings_it_cannot_place():
 def test_analyte_observations_rejects_an_unknown_analyte(woelfel_dataset):
     with pytest.raises(ValueError, match="does not contain analyte"):
         sh.plot_analyte_observations(woelfel_dataset, "nope")
+
+
+def test_analyte_observations_raises_nothing_to_plot_when_only_qualitative():
+    """
+    An analyte whose every reading is qualitative is legitimate data, not a bug.
+
+    The schema allows "positive", "negative" and "inconclusive" as values, and
+    a study may report an analyte that way and no other. There is still nothing
+    to put on a pair of axes, so this stays an error -- but a distinguishable
+    one, so a batch renderer can skip the analyte instead of failing the build.
+    gerna2007prospective carries two such analytes and took the figure refresh
+    down with it when the only signal was a bare ValueError.
+    """
+    dataset = {
+        "analytes": {
+            "flu": {
+                "biomarker": "influenza",
+                "specimen": "nasopharyngeal_aspirate",
+                "unit": "gc/mL",
+                "reference_event": "hospital admission",
+            }
+        },
+        "participants": [
+            {"measurements": [{"analyte": "flu", "time": 0, "value": "positive"}]}
+        ],
+    }
+    with pytest.raises(sh.NothingToPlotError, match="nothing to plot"):
+        sh.plot_analyte_observations(dataset, "flu")
+
+
+def test_nothing_to_plot_is_still_a_value_error():
+    """Callers that predate the type, and catch ValueError, must keep working."""
+    assert issubclass(sh.NothingToPlotError, ValueError)


### PR DESCRIPTION
Fixes the Refresh Dataset Figures run that failed after #204 merged ([run 34399893394](https://github.com/shedding-hub/shedding-hub/actions/runs/34399893394)).

## What happened

The run rendered 416 figures correctly, then failed on two analytes:

```
2 figure(s) could not be rendered:
  gerna2007prospective / influenza / observations: ... nothing to plot.
  gerna2007prospective / hCoV_63 / observations: ... nothing to plot.
make: *** [Makefile:66: figures] Error 1
```

Each of those analytes carries exactly one measurement, and its value is the qualitative string `positive`:

| Analyte | Measurements | Numeric and plottable |
|---|---|---|
| influenza | 1 | 0 |
| hCoV_63 | 1 | 0 |

A figure needs a numeric time paired with a usable value, so there were no axes to draw. `plot_analyte_observations` raised, the renderer recorded a failure and returned 1, and that took `make figures` and the workflow down.

## Why this is a renderer gap, not bad data

Qualitative-only data is legitimate. The schema allows `positive`, `negative` and `inconclusive` as values, and studies report analytes that way.

The fitter already draws this distinction. `SheddingDataError` exists so the catalog builder can record an unfittable analyte as unsuitable rather than a bug, and the last build skipped 42 analytes on `no_positive_measurements` without complaint. Plotting had no equivalent, so a property of the data was indistinguishable from a genuine plotting bug.

## The change

`NothingToPlotError` fills that gap. It subclasses `ValueError`, so callers written against the old behaviour keep working. The renderer skips those analytes, giving them no figure and no index entry, and reports them separately from failures. A real rendering error still fails the job.

## Verification

Against the dataset that broke it:

```
wrote 2 figure(s): 0 fit, 2 observations-only
2 analyte(s) had nothing to plot and were skipped:
  gerna2007prospective / influenza
  gerna2007prospective / hCoV_63
RENDER_EXIT=0
```

```
687 passed
black --check .  ->  45 files would be left unchanged
```

Two new tests cover the contract: that a qualitative-only analyte raises the new type, and that it is still a `ValueError`.

## One thing I did not do

There is no test for the renderer script itself, because nothing under `scripts/` currently has test coverage and adding that harness is a larger change than this fix warrants. The exception contract is tested; the renderer's use of it is three lines, verified by hand above.

## After merging

Re-run Refresh Dataset Figures by hand. It is `workflow_dispatch` as well as push-triggered, and the figures for the 20 new datasets are still unbuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6NxCZWQLc5NAbxAineEdC